### PR TITLE
Change default peer handling for rolling.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -141,18 +141,21 @@ Annotate a table expression to compute rolling aggregate or window functions wit
 
 * *expr*: The table expression to annotate.
 * *frame*:The sliding window frame offsets. Each entry indicates an offset from the current value. If an entry is non-finite, the frame will be unbounded in that direction, including all preceding or following values. If unspecified or `null`, the default frame `[-Infinity, 0]` includes the current values and all preceding values.
-* *ignorePeers*: Boolean flag indicating if the sliding window frame should ignore peer (tied) values. If `false` (the default), the window frame expands to include all peers ([following default SQL window semantics](https://www.postgresql.org/docs/9.3/functions-window.html)). If `true`, the window frame is defined by the frame offsets only, with peer rows treated as separate values. This parameter only affects operations that depend on the window frame, namely [aggregate functions](op/#aggregate-functions) and the [first_value](op/#first_value), [last_value](op/#last_value), and [nth_value](op/#last_values) window functions.
+* *includePeers*: Boolean flag indicating if the sliding window frame should ignore peer (tied) values. If `false` (the default), the window frame boundaries are insensitive to peer values. If `true`, the window frame expands to include all peers. This parameter only affects operations that depend on the window frame: namely [aggregate functions](op/#aggregate-functions) and the [first_value](op/#first_value), [last_value](op/#last_value), and [nth_value](op/#last_values) window functions.
 
 *Examples*
 
 ```js
-aq.rolling(d => mean(d.colA), [-3, 3]) // centered 7-day moving average, assuming one value per day
+aq.rolling(d => op.sum(d.colA)) // cumulative sum
 ```
 
 ```js
-aq.rolling(d => sum(d.colA), null, true) // cumulative sum that does not group tied values
+aq.rolling(d => op.mean(d.colA), [-3, 3]) // centered 7-day moving average, assuming one value per day
 ```
 
+```js
+aq.rolling(d => op.last_value(d.colA), [-3, 3], true) // last value in frame, including peers (ties)
+```
 
 <hr/><a id="seed" href="#seed">#</a>
 <em>aq</em>.<b>seed</b>(<i>value</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/util/random.js)

--- a/src/verbs/expr/rolling.js
+++ b/src/verbs/expr/rolling.js
@@ -11,20 +11,21 @@ import wrap from './wrap';
  *  entry is non-finite, the frame will be unbounded in that direction,
  *  including all preceding or following values. If unspecified, the frame
  *  will include the current values and all preceding values.
- * @param {boolean} [ignorePeers=false] Indicates if the sliding window frame
+ * @param {boolean} [includePeers=false] Indicates if the sliding window frame
  *  should ignore peer (tied) values. If false (the default), the window frame
- *  expands to include all peers. If true, the window frame is defined by the
- *  frame offsets only. This parameter only affects operations that depend on
- *  the window frame: aggregate functions and the first_value, last_value,
- *  and nth_value window functions.
+ *  boundaries are insensitive to peer values. If `true`, the window frame
+ *  expands to include all peers. This parameter only affects operations that
+ *  depend on the window frame: aggregate functions and the first_value,
+ *  last_value, and nth_value window functions.
  * @return A new wrapped expression annotated with rolling window parameters.
  * @example rolling(d => mean(d.colA), [-3, 3])
+ * @example rolling(d => last_value(d.colA), null, true)
  */
-export default function(expr, frame, ignorePeers) {
+export default function(expr, frame, includePeers) {
   return wrap(expr, {
     window: {
       frame: frame || [-Infinity, 0],
-      peers: !ignorePeers
+      peers: !!includePeers
     }
   });
 }


### PR DESCRIPTION
Change the `rolling` helper to be *insensitive* to peer values (ties) by default. This is a breaking change, but seems likely to bring the API more in line with user expectations: the most common peer-sensitive window operations are rolling aggregates (like cumulative sums or windowed counts) where people are unlikely to know in advance about window frame adjustments to include all peer values.