### PR TITLE
Add row object iterator support.

### DIFF
--- a/src/table/table.js
+++ b/src/table/table.js
@@ -230,6 +230,14 @@ export default class Table {
   }
 
   /**
+   * Returns an iterator over objects representing table rows.
+   * @return {Iterator} An iterator over row objects.
+   */
+  [Symbol.iterator]() {
+    error('Not implemented');
+  }
+
+  /**
    * Print the contents of this table using the console.table() method.
    * @param {ObjectsOptions} options The options for row object generation,
    *  determining which rows and columns are printed.
@@ -350,7 +358,7 @@ export default class Table {
     const stop = () => i = this._total;
 
     if (order && this.isOrdered() || filter && this._index) {
-      const index = this._index = this.indices();
+      const index = this.indices();
       const data = this._data;
       for (; i < nrows; ++i) {
         fn(index[i], data, stop);

--- a/src/util/row-object-builder.js
+++ b/src/util/row-object-builder.js
@@ -1,0 +1,10 @@
+import unroll from './unroll';
+
+export default function(table, names) {
+  names = names || table.columnNames();
+  return unroll(
+    names.map(name => table.column(name)),
+    'row',
+    '({' + names.map((_, i) => `${JSON.stringify(_)}:_${i}.get(row)`) + '})'
+  );
+}

--- a/test/table/column-table-test.js
+++ b/test/table/column-table-test.js
@@ -117,6 +117,30 @@ tape('ColumnTable supports object output', t => {
   t.end();
 });
 
+tape('ColumnTable supports iterator output', t => {
+  const output = [
+    { u: 'a', v: 2 },
+    { u: 'a', v: 1 },
+    { u: 'a', v: 4 },
+    { u: 'b', v: 5 },
+    { u: 'b', v: 3 }
+  ];
+
+  const dt = new ColumnTable({
+      u: ['a', 'a', 'a', 'b', 'b'],
+      v: [2, 1, 4, 5, 3]
+    });
+
+  t.deepEqual([...dt], output, 'iterator data');
+  t.deepEqual(
+    [...dt.orderby('v')],
+    output.slice().sort((a, b) => a.v - b.v),
+    'iterator data orderby'
+  );
+
+  t.end();
+});
+
 tape('ColumnTable toString shows table state', t => {
   const dt = new ColumnTable({
     a: ['a', 'a', 'a', 'b', 'b'],


### PR DESCRIPTION
Adds default iterator support to Arquero tables, producing output row objects.

Close #7