### PR TITLE
fix: Call create method on cume_dist

### DIFF
--- a/src/op/window-functions.js
+++ b/src/op/window-functions.js
@@ -141,7 +141,7 @@ export default {
     create(num) {
       num = +num;
       if (!(num > 0)) error('ntile num must be greater than zero.');
-      const { init, value } = cume_dist();
+      const { init, value } = cume_dist.create();
       return {
         init,
         value: w => Math.ceil(num * value(w))


### PR DESCRIPTION
Using ntile op results in "cume_dist is not a function" error. It was calling the object instead of its create method.