### PR TITLE
Support natural join.

### DIFF
--- a/src/verbs/join.js
+++ b/src/verbs/join.js
@@ -3,6 +3,7 @@ import parseKey from './expr/parse-key';
 import parseValue from './expr/parse';
 import { all, not } from './expr/selection';
 import parse from '../expression/parse';
+import error from '../util/error';
 import has from '../util/has';
 import intersect from '../util/intersect';
 import isArray from '../util/is-array';
@@ -10,12 +11,16 @@ import isArray from '../util/is-array';
 const OPT_L = { aggregate: false, window: false };
 const OPT_R = { ...OPT_L, index: 1 };
 
-export default function(tableL, tableR, on, values, options) {
+export default function(tableL, tableR, on, values, options = {}) {
   if (!on) {
     // perform natural join if join condition not provided
     const isect = intersect(tableL.columnNames(), tableR.columnNames());
+    if (!isect.length) error('Natural join requires shared column names.');
     on = [isect, isect];
-    if (!values) values = [all(), not(isect)];
+    if (!(values || options.left && options.right)) {
+      values = [all(), not(isect)];
+      if (options.right) values.reverse();
+    }
   }
 
   if (!values) {

--- a/src/verbs/join.js
+++ b/src/verbs/join.js
@@ -1,7 +1,7 @@
 import _join from '../engine/join';
 import parseKey from './expr/parse-key';
 import parseValue from './expr/parse';
-import { all } from './expr/selection';
+import { all, not } from './expr/selection';
 import parse from '../expression/parse';
 import has from '../util/has';
 import intersect from '../util/intersect';
@@ -15,6 +15,7 @@ export default function(tableL, tableR, on, values, options) {
     // perform natural join if join condition not provided
     const isect = intersect(tableL.columnNames(), tableR.columnNames());
     on = [isect, isect];
+    if (!values) values = [all(), not(isect)];
   }
 
   if (!values) {

--- a/test/verbs/join-test.js
+++ b/test/verbs/join-test.js
@@ -89,6 +89,12 @@ tape('join performs natural join', t => {
     b: [ 5, 6, 2 ]
   }, 'natural right join data, common columns');
 
+  tableEqual(t, tl.join_full(t1), {
+    k: [ 1, 2, 3, 4 ],
+    a: [ 3, 4, 1, undefined ],
+    b: [ 5, 6, undefined, 2 ]
+  }, 'natural full join data, common columns');
+
   t.throws(
     () =>tl.join(t2),
     'natural join throws, no common columns'
@@ -99,23 +105,26 @@ tape('join performs natural join', t => {
 
 tape('join handles filtered tables', t => {
   const tl = table({
-      key: [1, 2, 3, 4],
-      value1: [1, 2, 3, 4]
-    })
-    .filter(d => d.key < 3);
+    key: [1, 2, 3, 4],
+    value1: [1, 2, 3, 4]
+  }).filter(d => d.key < 3);
 
   const tr = table({
-      key: [1, 2, 5],
-      value2: [1, 2, 5]
-    });
+    key: [1, 2, 5],
+    value2: [1, 2, 5]
+  });
 
-  const tj = tl.join_left(tr, null, [all(), not('key')]);
-
-  tableEqual(t, tj, {
+  tableEqual(t, tl.join_left(tr), {
     key: [ 1, 2 ],
     value1: [ 1, 2 ],
     value2: [ 1, 2 ]
-  }, 'natural join on filtered data');
+  }, 'natural left join on filtered data');
+
+  tableEqual(t, tl.join_right(tr), {
+    key: [ 1, 2, 5 ],
+    value1: [ 1, 2, undefined ],
+    value2: [ 1, 2, 5 ]
+  }, 'natural left join on filtered data');
 
   t.end();
 });
@@ -280,6 +289,15 @@ tape('join_full performs full outer join with keys', t => {
 tape('join handles column name collisions', t => {
   const [tl] = joinTables();
   const tr = table({ k: ['a', 'b'], x: [9, 8] });
+
+  const tj0 = tl.join(tr, 'k');
+
+  tableEqual(t, tj0, {
+    k: [ 'a', 'b', 'b' ],
+    x_1: [ 1, 2, 3 ],
+    y: [ 9, 8, 7 ],
+    x_2: [ 9, 8, 8 ]
+  }, 'name collision join data');
 
   const tj1 = tl.join(tr, ['k', 'k'], [all(), all()]);
 

--- a/test/verbs/join-test.js
+++ b/test/verbs/join-test.js
@@ -290,17 +290,23 @@ tape('join handles column name collisions', t => {
   const [tl] = joinTables();
   const tr = table({ k: ['a', 'b'], x: [9, 8] });
 
-  const tj0 = tl.join(tr, 'k');
-
-  tableEqual(t, tj0, {
+  const tj_inner = tl.join(tr, 'k');
+  tableEqual(t, tj_inner, {
     k: [ 'a', 'b', 'b' ],
     x_1: [ 1, 2, 3 ],
     y: [ 9, 8, 7 ],
     x_2: [ 9, 8, 8 ]
-  }, 'name collision join data');
+  }, 'name collision inner join data');
+
+  const tj_full = tl.join_full(tr, 'k');
+  tableEqual(t, tj_full, {
+    k: [ 'a', 'b', 'b', 'c' ],
+    x_1: [ 1, 2, 3, 4 ],
+    y: [ 9, 8, 7, 6 ],
+    x_2: [ 9, 8, 8, undefined ]
+  }, 'name collision full join data');
 
   const tj1 = tl.join(tr, ['k', 'k'], [all(), all()]);
-
   tableEqual(t, tj1, {
     k_1: [ 'a', 'b', 'b' ],
     x_1: [ 1, 2, 3 ],
@@ -314,7 +320,6 @@ tape('join handles column name collisions', t => {
     all(),
     { y: (a, b) => a.x + b.x }
   ]);
-
   tableEqual(t, tj2, {
     k_1: [ 'a', 'b', 'b' ],
     x_1: [ 1, 2, 3 ],

--- a/test/verbs/join-test.js
+++ b/test/verbs/join-test.js
@@ -67,8 +67,8 @@ tape('cross computes Cartesian product with column renaming', t => {
 });
 
 tape('join performs natural join', t => {
-  const tl = table({ k: [1, 2], a: [3, 4]});
-  const t1 = table({ k: [1, 2], b: [5, 6]});
+  const tl = table({ k: [1, 2, 3], a: [3, 4, 1]});
+  const t1 = table({ k: [1, 2, 4], b: [5, 6, 2]});
   const t2 = table({ u: [1, 2], v: [5, 6]});
 
   tableEqual(t, tl.join(t1), {
@@ -77,12 +77,22 @@ tape('join performs natural join', t => {
     b: [ 5, 6 ]
   }, 'natural join data, common columns');
 
-  tableEqual(t, tl.join(t2), {
-    k: [ 1, 1, 2, 2 ],
-    a: [ 3, 3, 4, 4 ],
-    u: [ 1, 2, 1, 2 ],
-    v: [ 5, 6, 5, 6 ]
-  }, 'natural join data, no common columns');
+  tableEqual(t, tl.join_left(t1), {
+    k: [ 1, 2, 3 ],
+    a: [ 3, 4, 1 ],
+    b: [ 5, 6, undefined ]
+  }, 'natural left join data, common columns');
+
+  tableEqual(t, tl.join_right(t1), {
+    k: [ 1, 2, 4 ],
+    a: [ 3, 4, undefined ],
+    b: [ 5, 6, 2 ]
+  }, 'natural right join data, common columns');
+
+  t.throws(
+    () =>tl.join(t2),
+    'natural join throws, no common columns'
+  );
 
   t.end();
 });

--- a/test/verbs/join-test.js
+++ b/test/verbs/join-test.js
@@ -73,9 +73,8 @@ tape('join performs natural join', t => {
   const tj = tl.join(tr);
 
   tableEqual(t, tj, {
-    k_1: [ 1, 2 ],
+    k: [ 1, 2 ],
     a: [ 3, 4 ],
-    k_2: [ 1, 2 ],
     b: [ 5, 6 ]
   }, 'natural join data');
 

--- a/test/verbs/join-test.js
+++ b/test/verbs/join-test.js
@@ -68,15 +68,21 @@ tape('cross computes Cartesian product with column renaming', t => {
 
 tape('join performs natural join', t => {
   const tl = table({ k: [1, 2], a: [3, 4]});
-  const tr = table({ k: [1, 2], b: [5, 6]});
+  const t1 = table({ k: [1, 2], b: [5, 6]});
+  const t2 = table({ u: [1, 2], v: [5, 6]});
 
-  const tj = tl.join(tr);
-
-  tableEqual(t, tj, {
+  tableEqual(t, tl.join(t1), {
     k: [ 1, 2 ],
     a: [ 3, 4 ],
     b: [ 5, 6 ]
-  }, 'natural join data');
+  }, 'natural join data, common columns');
+
+  tableEqual(t, tl.join(t2), {
+    k: [ 1, 1, 2, 2 ],
+    a: [ 3, 3, 4, 4 ],
+    u: [ 1, 2, 1, 2 ],
+    v: [ 5, 6, 5, 6 ]
+  }, 'natural join data, no common columns');
 
   t.end();
 });


### PR DESCRIPTION
- Update `join()` to drop redundant columns when performing a natural join (that is, when neither a join predicate / keys nor specific output columns are provided).

Close #25.