### PR TITLE
Update format and export options.

### DIFF
--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -190,6 +190,7 @@ Returns an array of objects representing table rows. A new set of objects will b
 
 * *options*: Options for row generation:
   * *limit*: The maximum number of objects to create (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
 
 <hr/><a id="@@iterator" href="#@@iterator">#</a>
 <em>table</em>\[<b>Symbol.iterator</b>\]() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
@@ -216,6 +217,7 @@ Print the contents of this table using the `console.table()` method.
 
 * *options*: Options for printing, typically an object value. If number-valued, the call is equivalent to `{ limit: value }`.
   * *limit*: The maximum number of rows to print (default `10`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
 
 <hr/><a id="toCSV" href="#toCSV">#</a>
 <em>table</em>.<b>toCSV</b>([<i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/to-csv.js)
@@ -225,6 +227,7 @@ Format this table as a comma-separated values (CSV) string. Other delimiters, su
 * *options*: A formatting options object:
   * *delimiter*: The delimiter between values (default `","`).
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to include. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions to invoke to transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
 
@@ -235,6 +238,7 @@ Format this table as an HTML table string.
 
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:
@@ -250,6 +254,7 @@ Format this table as a JavaScript Object Notation (JSON) string.
 
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions to invoke to transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
 
@@ -260,6 +265,7 @@ Format this table as a [GitHub-Flavored Markdown table](https://github.github.co
 
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -240,6 +240,7 @@ Format this table as an HTML table string.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:
     * *date*: One of 'utc' or 'loc' (for UTC or local dates), or `null` for complete date time strings.
     * *digits*: Number of significant digits to include for numbers.
+  * *null*: Optional format function for `null` and `undefined` values. If specified, this function be invoked with the `null` or `undefined` value as the sole input argument. The return value is then used as the HTML output for the input value.
   * *style*: CSS styles to include in HTML output. The object keys can be HTML table tag names: `'table'`, `'thead'`, `'tbody'`, `'tr'`, `'th'`, or `'td'`. The object values should be strings of valid CSS style directives (such as `"font-weight: bold;"`) or functions that take a column name and row as inputs and return a CSS string.
 
 <hr/><a id="toJSON" href="#toJSON">#</a>

--- a/src/format/to-csv.js
+++ b/src/format/to-csv.js
@@ -7,6 +7,7 @@ import isDate from '../util/is-date';
  * @typedef {Object} CSVFormatOptions
  * @property {string} [delimiter=','] The delimiter between values.
  * @property {number} [limit=Infinity] The maximum number of rows to print.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]|Function} [columns] Ordered list of column names
  *  to include. If function-valued, the function should accept a table as
  *  input and return an array of column name strings.
@@ -38,7 +39,7 @@ export default function(table, options = {}) {
   const vals = names.map(formatValue);
   let text = '';
 
-  scan(table, names, options.limit, {
+  scan(table, names, options.limit, options.offset, {
     row() {
       text += vals.join(delim) + '\n';
     },

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -7,6 +7,7 @@ import mapObject from '../util/map-object';
  * Options for HTML formatting.
  * @typedef {Object} HTMLOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
  * @property {Object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
@@ -67,7 +68,7 @@ export default function(table, options = {}) {
     + '</tr></thead>'
     + tag('tbody');
 
-  scan(table, names, options.limit, {
+  scan(table, names, options.limit, options.offset, {
     row(row) {
       r = row;
       text += (++idx ? '</tr>' : '') + tag('tr');

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -18,6 +18,10 @@ import mapObject from '../util/map-object';
  *  If specified, these override the automatically inferred options.
  *  - {string} date One of 'utc' or 'loc' (for UTC or local dates), or null for full date times.
  *  - {number} digits Number of significant digits to include for numbers.
+ * @property {Function} [null] Format function for null and undefined values.
+ *  If specified, this function will be invoked with the null or undefined
+ *  value as the sole input, and the return value will be used as the HTML
+ *  output for the value.
  * @property {Object} [style] CSS styles to include in HTML output.
  *  The object keys should be HTML table tag names: 'table', 'thead',
  *  'tbody', 'tr', 'th', or 'td'. The object values should be strings of
@@ -35,11 +39,16 @@ export default function(table, options = {}) {
   const names = columns(table, options.columns);
   const { align, format } = formats(table, names, options);
   const style = styles(options);
+  const nullish = options.null;
 
   const alignValue = a => a === 'c' ? 'center' : a === 'r' ? 'right' : 'left';
   const escape = s => s.replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+  const baseFormat = (value, opt) => escape(formatValue(value, opt));
+  const formatter = nullish
+    ? (value, opt) => value == null ? nullish(value) : baseFormat(value, opt)
+    : baseFormat;
 
   let r = -1;
   let idx = -1;
@@ -65,7 +74,7 @@ export default function(table, options = {}) {
     },
     cell(value, name) {
       text += tag('td', name)
-        + escape(formatValue(value, format[name]))
+        + formatter(value, format[name])
         + '</td>';
     }
   });

--- a/src/format/to-markdown.js
+++ b/src/format/to-markdown.js
@@ -5,6 +5,7 @@ import { columns, formats, scan } from './util';
  * Options for Markdown formatting.
  * @typedef {Object} MarkdownOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
  * @property {Object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
@@ -37,7 +38,7 @@ export default function(table, options = {}) {
     + names.map(name => alignValue(align[name])).join('|')
     + '|';
 
-  scan(table, names, options.limit, {
+  scan(table, names, options.limit, options.offset, {
     row() {
       text += '\n|';
     },

--- a/src/format/util.js
+++ b/src/format/util.js
@@ -7,10 +7,6 @@ export function columns(table, names) {
     : names || table.columnNames();
 }
 
-export function numRows(table, limit) {
-  return limit !== 0 ? Math.min(limit || Infinity, table.numRows()) : 0;
-}
-
 export function formats(table, names, options) {
   const formatOpt = options.format || {};
   const alignOpt = options.align || {};
@@ -31,18 +27,13 @@ function values(table, columnName) {
   return fn => table.scan(row => fn(column.get(row)));
 }
 
-export function scan(table, names, limit, ctx) {
-  limit = numRows(table, limit);
-  if (limit <= 0) return;
-
+export function scan(table, names, limit, offset, ctx) {
   const n = names.length;
-  let r = 0;
-  table.scan((row, data, stop) => {
+  table.scan(row => {
     ctx.row(row);
     for (let i = 0; i < n; ++i) {
       const name = names[i];
       ctx.cell(table.get(name, row), name, i);
     }
-    if (++r >= limit) stop();
-  }, true);
+  }, true, limit, offset);
 }

--- a/src/table/bit-set.js
+++ b/src/table/bit-set.js
@@ -57,6 +57,12 @@ export default class BitSet {
     return -1;
   }
 
+  nth(n) {
+    let i = this.next(0);
+    while (n-- && i >= 0) i = this.next(i + 1);
+    return i;
+  }
+
   not() {
     const bits = this._bits;
     const n = bits.length;

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -2,7 +2,6 @@ import Column from './column';
 import columnsFrom from './columns-from';
 import Table from './table';
 import { regroup, reindex } from './regroup';
-import { numRows } from '../format/util';
 import toCSV from '../format/to-csv';
 import toHTML from '../format/to-html';
 import toJSON from '../format/to-json';
@@ -111,17 +110,11 @@ export default class ColumnTable extends Table {
    * @return {Array} An array of row objects.
    */
   objects(options = {}) {
-    const limit = numRows(this, options.limit);
-    if (limit <= 0) return [];
-    const tuples = Array(limit);
     const create = rowObjectBuilder(this);
-
-    let r = 0;
-    this.scan((row, data, stop) => {
-      tuples[r] = create(row);
-      if (++r >= limit) stop();
-    }, true);
-
+    const tuples = [];
+    this.scan(row => {
+      tuples.push(create(row));
+    }, true, options.limit, options.offset);
     return tuples;
   }
 

--- a/test/format/html-test.js
+++ b/test/format/html-test.js
@@ -103,3 +103,29 @@ tape('toHTML formats html table text with style option', t => {
 
   t.end();
 });
+
+tape('toHTML formats html table text with null option', t => {
+  const a = 'style="text-align: right;"';
+  const html = (a) => [
+    '<table><thead>',
+    '<tr><th>u</th></tr>',
+    '</thead><tbody>',
+    `<tr><td ${a}>a</td></tr>`,
+    `<tr><td ${a}>0</td></tr>`,
+    `<tr><td ${a}><span class="null">null</span></td></tr>`,
+    `<tr><td ${a}><span class="null">undefined</span></td></tr>`,
+    '</tbody></table>'
+  ];
+
+  const dt = new ColumnTable({ u: ['a', 0, null, undefined] });
+
+  t.equal(
+    toHTML(dt, {
+      null: v => `<span class="null">${v}</span>`
+    }),
+    html(a).join(''),
+    'html text with custom null format'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
- Add `null` option to `toHTML` to specialize formatting of null and undefined values.
- Add `offset` option for output formats.
- Add `limit` and `offset` arguments to table `scan` method.