### PR TITLE
Add relocate verb, add derive before/after options.

### DIFF
--- a/src/query/verb.js
+++ b/src/query/verb.js
@@ -128,7 +128,10 @@ export const Verbs = {
                 { name: 'keys', type: ExprList, default: [] }
               ]),
   derive:     createVerb('derive', [
-                { name: 'values', type: ExprObject }
+                { name: 'values', type: ExprObject },
+                { name: 'options', type: Options,
+                  props: { before: SelectionList, after: SelectionList }
+                }
               ]),
   filter:     createVerb('filter', [
                 { name: 'criteria', type: ExprObject }
@@ -138,6 +141,12 @@ export const Verbs = {
               ]),
   orderby:    createVerb('orderby', [
                 { name: 'keys', type: OrderbyKeys }
+              ]),
+  relocate:   createVerb('relocate', [
+                { name: 'columns', type: SelectionList },
+                { name: 'options', type: Options,
+                  props: { before: SelectionList, after: SelectionList }
+                }
               ]),
   rollup:     createVerb('rollup', [
                 { name: 'values', type: ExprObject }
@@ -206,143 +215,3 @@ export const Verbs = {
                 { name: 'tables', type: TableRefList }
               ])
 };
-
-
-// export const Reify = createVerb('reify');
-
-// export const Count = createVerb('count', [
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Dedupe = createVerb('dedupe', [
-//   { name: 'keys', type: ExprList, default: [] }
-// ]);
-
-// export const Derive = createVerb('derive', [
-//   { name: 'values', type: ExprObject }
-// ]);
-
-// export const Filter = createVerb('filter', [
-//   { name: 'criteria', type: ExprObject }
-// ]);
-
-// export const Groupby = createVerb('groupby', [
-//   { name: 'keys', type: ExprList }
-// ]);
-
-// export const Orderby = createVerb('orderby', [
-//   { name: 'keys', type: OrderbyKeys }
-// ]);
-
-// export const Rollup = createVerb('rollup', [
-//   { name: 'values', type: ExprObject }
-// ]);
-
-// export const Sample = createVerb('sample', [
-//   { name: 'size', type: ExprNumber },
-//   { name: 'options', type: Options, props: { weight: Expr } }
-// ]);
-
-// export const Select = createVerb('select', [
-//   { name: 'columns', type: SelectionList }
-// ]);
-
-// export const Ungroup = createVerb('ungroup');
-
-// export const Unorder = createVerb('unorder');
-
-// export const Fold = createVerb('fold', [
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Pivot = createVerb('pivot', [
-//   { name: 'keys', type: ExprList },
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Spread = createVerb('spread', [
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Unroll = createVerb('unroll', [
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options, props: { drop: ExprList } }
-// ]);
-
-// export const Lookup = createVerb('lookup', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys },
-//   { name: 'values', type: ExprList }
-// ]);
-
-// export const Join = createVerb('join', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys },
-//   { name: 'values', type: JoinValues },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Cross = createVerb('cross', [
-//   { name: 'table', type: TableRef },
-//   { name: 'values', type: JoinValues },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Semijoin = createVerb('semijoin', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys }
-// ]);
-
-// export const Antijoin = createVerb('antijoin', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys }
-// ]);
-
-// export const Concat = createVerb('concat', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// export const Union = createVerb('union', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// export const Intersect = createVerb('intersect', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// export const Except = createVerb('except', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// /**
-//  * A lookup table of verb classes.
-//  */
-// export const Verbs = {
-//   count:     Count,
-//   dedupe:    Dedupe,
-//   derive:    Derive,
-//   filter:    Filter,
-//   groupby:   Groupby,
-//   orderby:   Orderby,
-//   rollup:    Rollup,
-//   sample:    Sample,
-//   select:    Select,
-//   ungroup:   Ungroup,
-//   unorder:   Unorder,
-//   fold:      Fold,
-//   pivot:     Pivot,
-//   spread:    Spread,
-//   unroll:    Unroll,
-//   lookup:    Lookup,
-//   join:      Join,
-//   cross:     Cross,
-//   semijoin:  Semijoin,
-//   antijoin:  Antijoin,
-//   concat:    Concat,
-//   union:     Union,
-//   intersect: Intersect,
-//   except:    Except
-// };

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -434,15 +434,23 @@ export default class Table {
   }
 
   /**
-   * Derive new column values based on the provided expressions.
+   * Derive new column values based on the provided expressions. By default,
+   * new columns are added after (higher indices than) existing columns. Use
+   * the before or after options to place new columns elsewhere.
    * @param {Object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
+   * @param {RelocateOptions} options Options for relocating derived columns.
+   *  Use either a before or after property to indicate where to place
+   *  derived columns. Specifying both before and after is an error. Unlike
+   *  the relocate verb, this option affects only new columns; updated
+   *  columns with existing names are excluded from relocation.
    * @return {Table} A new table with derived columns added.
    * @example table.derive({ sumXY: d => d.x + d.y })
+   * @example table.derive({ z: d => d.x * d.y }, { before: 'x' })
    */
-  derive(values) {
-    return this.__derive(this, values);
+  derive(values, options) {
+    return this.__derive(this, values, options);
   }
 
   /**
@@ -515,6 +523,45 @@ export default class Table {
    */
   reduce(reducer) {
     return this.__reduce(this, reducer);
+  }
+
+  /**
+   * Options for relocate transformations.
+   * @typedef {Object} RelocateOptions
+   * @property {string|string[]|number|number[]|Object|Function} [before]
+   *  An anchor column that relocated columns should be placed before.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the first column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   * @property {string|string[]|number|number[]|Object|Function} [after]
+   *  An anchor column that relocated columns should be placed after.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the last column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   */
+
+  /**
+   * Relocate a subset of columns to change their positions, also
+   * potentially renaming them.
+   * @param {string|string[]|number|number[]|Object|Function} columns An
+   * ordered selection of columns to relocate. The input may consist of:
+   *  - column name strings,
+   *  - column integer indices,
+   *  - objects with current column names as keys and new column names as
+   *    values (for renaming), or
+   *  - functions that take a table as input and returns a valid selection
+   *    parameter (typically the output of the selection helper functions
+   *    {@link all}, {@link not}, or {@link range}).
+   * @param {RelocateOptions} options Options for relocating. Must include
+   *  either the before or after property to indicate where to place the
+   *  relocated columns. Specifying both before and after is an error.
+   * @return {Table} A new table with relocated columns.
+   * @example table.relocate(['colY', 'colZ'], { after: 'colX' })
+   * @example table.relocate(not('colB', 'colC'), { before: 'colA' })
+   * @example table.relocate({ colA: 'newA', colB: 'newB' }, { after: 'colC' })
+   */
+  relocate(columns, options) {
+    return this.__relocate(this, columns, options);
   }
 
   /**

--- a/src/verbs/derive.js
+++ b/src/verbs/derive.js
@@ -1,6 +1,14 @@
+import relocate from './relocate';
 import _derive from '../engine/derive';
 import parse from '../expression/parse';
 
-export default function(table, values) {
-  return _derive(table, parse(values, { table }));
+export default function(table, values, options = {}) {
+  const dt = _derive(table, parse(values, { table }));
+
+  return options.before == null && options.after == null
+    ? dt
+    : relocate(dt,
+        Object.keys(values).filter(name => table.columnIndex(name) >= 0),
+        options
+      );
 }

--- a/src/verbs/expr/selection.js
+++ b/src/verbs/expr/selection.js
@@ -4,6 +4,7 @@ import isFunction from '../../util/is-function';
 import isObject from '../../util/is-object';
 import isNumber from '../../util/is-number';
 import isString from '../../util/is-string';
+import toString from '../../util/to-string';
 
 export default function resolve(table, sel, map = {}) {
   sel = isNumber(sel) ? table.columnName(sel) : sel;
@@ -17,7 +18,7 @@ export default function resolve(table, sel, map = {}) {
   } else if (isObject(sel)) {
     Object.assign(map, sel);
   } else {
-    error(`Invalid column selection: ${sel+''}`);
+    error(`Invalid column selection: ${toString(sel)}`);
   }
 
   return map;

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -8,6 +8,7 @@ import __join from './join';
 import __join_filter from './join-filter';
 import __lookup from './lookup';
 import __pivot from './pivot';
+import __relocate from './relocate';
 import __rollup from './rollup';
 import __sample from './sample';
 import __select from './select';
@@ -37,6 +38,7 @@ Object.assign(ColumnTable.prototype, {
   __join_filter,
   __lookup,
   __pivot,
+  __relocate,
   __rollup,
   __sample,
   __select,

--- a/src/verbs/relocate.js
+++ b/src/verbs/relocate.js
@@ -1,0 +1,38 @@
+import _select from '../engine/select';
+import resolve from './expr/selection';
+import error from '../util/error';
+import has from '../util/has';
+
+export default function(table, columns, { before, after } = {}) {
+  const bef = before != null;
+  const aft = after != null;
+
+  if (!(bef || aft)) {
+    error('relocate requires a before or after option.');
+  }
+  if (bef && aft) {
+    error('relocate accepts only one of the before or after options.');
+  }
+
+  columns = resolve(table, columns);
+  const anchors = Object.keys(resolve(table, bef ? before : after));
+  const anchor = bef ? anchors[0] : anchors.pop();
+  const _cols = {};
+
+  // marshal inputs to select in desired order
+  table.columnNames().forEach(name => {
+    // check if we should assign the current column
+    const assign = !has(columns, name);
+
+    // at anchor column, insert relocated columns
+    if (name === anchor) {
+      if (bef && assign) _cols[name] = name;
+      Object.assign(_cols, columns);
+      if (bef) return; // exit if current column has been handled
+    }
+
+    if (assign) _cols[name] = name;
+  });
+
+  return _select(table, _cols);
+}

--- a/test/query/query-builder-test.js
+++ b/test/query/query-builder-test.js
@@ -2,6 +2,8 @@ import tape from 'tape';
 import { desc, not, op } from '../../src/verbs';
 import { field, func } from './util';
 import { query } from '../../src/query/query-builder';
+import { Verbs } from '../../src/query/verb';
+import isFunction from '../../src/util/is-function';
 
 tape('query builder builds single-table queries', t => {
   const q = query()
@@ -14,7 +16,8 @@ tape('query builder builds single-table queries', t => {
     verbs: [
       {
         verb: 'derive',
-        values: { bar: func('d => d.foo + 1') }
+        values: { bar: func('d => d.foo + 1') },
+        options: undefined
       },
       {
         verb: 'rollup',
@@ -99,5 +102,16 @@ tape('query builder supports multi-table queries', t => {
     ]
   }, 'serialized query from builder');
 
+  t.end();
+});
+
+tape('query builder supports all defined verbs', t => {
+  const verbs = Object.keys(Verbs);
+  const q = query();
+  t.equal(
+    verbs.filter(v => isFunction(q[v])).length,
+    verbs.length,
+    'query builder supports all verbs'
+  );
   t.end();
 });

--- a/test/query/verb-to-ast-test.js
+++ b/test/query/verb-to-ast-test.js
@@ -6,7 +6,7 @@ import { all, bin, desc, not, op, range, rolling } from '../../src/verbs';
 const {
   count, dedupe, derive, filter, groupby, orderby,
   reify, rollup, sample, select, ungroup, unorder,
-  pivot, unroll, join, concat
+  relocate, pivot, unroll, join, concat
 } = Verbs;
 
 function toAST(verb) {
@@ -65,12 +65,17 @@ tape('dedupe verb serializes to AST', t => {
 });
 
 tape('derive verb serializes to AST', t => {
-  const verb = derive({
-    col: d => d.foo,
-    foo: 'd.bar * 5',
-    bar: d => d.foo + 1,
-    baz: rolling(d => op.mean(d.foo), [-3, 3])
-  });
+  const verb = derive(
+    {
+      col: d => d.foo,
+      foo: 'd.bar * 5',
+      bar: d => d.foo + 1,
+      baz: rolling(d => op.mean(d.foo), [-3, 3])
+    },
+    {
+      before: 'bop'
+    }
+  );
 
   t.deepEqual(
     toAST(verb),
@@ -104,7 +109,12 @@ tape('derive verb serializes to AST', t => {
           },
           as: 'baz'
         }
-      ]
+      ],
+      options: {
+        before: [
+          { type: 'Column', name: 'bop' }
+        ]
+      }
     },
     'ast derive verb'
   );
@@ -231,6 +241,54 @@ tape('reify verb serializes to AST', t => {
     toAST(verb),
     { type: 'Verb', verb: 'reify' },
     'ast reify verb'
+  );
+
+  t.end();
+});
+
+tape('relocate verb serializes to AST', t => {
+  t.deepEqual(
+    toAST(relocate(['foo', 'bar'], { before: 'baz' })),
+    {
+      type: 'Verb',
+      verb: 'relocate',
+      columns: [
+        { type: 'Column', name: 'foo' },
+        { type: 'Column', name: 'bar' }
+      ],
+      options: {
+        before: [ { type: 'Column', name: 'baz' } ]
+      }
+    },
+    'ast relocate verb'
+  );
+
+  t.deepEqual(
+    toAST(relocate(not('foo'), { after: range('a', 'b') })),
+    {
+      type: 'Verb',
+      verb: 'relocate',
+      columns: [
+        {
+          type: 'Selection',
+          operator: 'not',
+          arguments: [ { type: 'Column', name: 'foo' } ]
+        }
+      ],
+      options: {
+        after: [
+          {
+            type: 'Selection',
+            operator: 'range',
+            arguments: [
+              { type: 'Column', name: 'a' },
+              { type: 'Column', name: 'b' }
+            ]
+          }
+        ]
+      }
+    },
+    'ast relocate verb'
   );
 
   t.end();

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -29,6 +29,33 @@ tape('derive overwrites existing columns', t => {
   t.end();
 });
 
+tape('derive can relocate new columns', t => {
+  const data = {
+    a: [1, 3, 5, 7],
+    b: [2, 4, 6, 8]
+  };
+
+  tableEqual(t,
+    table(data).derive({ z: d => d.a + d.b }, { before: 'a' }),
+    { z: [3, 7, 11, 15], ...data },
+    'derive data, with before'
+  );
+
+  tableEqual(t,
+    table(data).derive({ z: d => d.a + d.b }, { after: 'a' }),
+    { a: data.a, z: [3, 7, 11, 15], b: data.b },
+    'derive data, with before'
+  );
+
+  tableEqual(t,
+    table(data).derive({ a: d => -d.a, z: d => d.a + d.b }, { after: 'b' }),
+    { a: [-1, -3, -5, -7], b: data.b, z: [3, 7, 11, 15] },
+    'derive data, with after and overwrite'
+  );
+
+  t.end();
+});
+
 tape('derive supports aggregate and window operators', t => {
   const n = 10;
   const k = Array(n);

--- a/test/verbs/relocate-test.js
+++ b/test/verbs/relocate-test.js
@@ -1,0 +1,86 @@
+import tape from 'tape';
+import tableEqual from '../table-equal';
+import { not, range, table } from '../../src/verbs';
+
+tape('relocate repositions columns', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { before: 'b' }),
+    { a, c, b, d },
+    'relocate data, before'
+  );
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { after: 'd' }),
+    { b, d, a, c },
+    'relocate data, after'
+  );
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { before: 'c' }),
+    { b, a, c, d },
+    'relocate data, before self'
+  );
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { after: 'a' }),
+    { a, c, b, d },
+    'relocate data, after self'
+  );
+
+  t.end();
+});
+
+tape('relocate repositions columns using multi-column anchor', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  tableEqual(t,
+    dt.relocate([1, 3], { before: range(2, 3) }),
+    { b, a, c, d },
+    'relocate data, before range'
+  );
+
+  tableEqual(t,
+    dt.relocate([1, 3], { after: range(2, 3) }),
+    { b, d, a, c },
+    'relocate data, after range'
+  );
+
+  t.end();
+});
+
+tape('relocate repositions and renames columns', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  tableEqual(t,
+    dt.relocate({ a: 'e', c: 'f' }, { before: { b: '?' } }),
+    { e: a, f: c, b, d },
+    'relocate data, before plus rename'
+  );
+
+  tableEqual(t,
+    dt.relocate({ a: 'e', c: 'f' }, { after: { b: '?' } }),
+    { b, d, e: a, f: c },
+    'relocate data, after plus rename'
+  );
+
+  t.end();
+});
+
+tape('relocate throws errors for invalid options', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  t.throws(() => dt.relocate(not('b', 'd')), 'missing options');
+  t.throws(() => dt.relocate(not('b', 'd'), {}), 'empty options');
+  t.throws(
+    () => dt.relocate(not('b', 'd'), { before: 'b', after: 'b' }),
+    'over-specified options'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
* Add `relocate` verb for repositioning and renaming columns.
* Add `derive` verb *before* and *after* options to position new derived columns.

Close #35