### PR TITLE
v1.2.0

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,6 +11,7 @@ title: Arquero API Reference
   * [op](#op), [bin](#bin), [desc](#desc), [rolling](#rolling), [seed](#seed)
 * [Selection Helpers](#selection-helpers)
   * [all](#all), [not](#not), [range](#range)
+  * [matches](#matches), [startswith](#startswith), [endswith](#endswith)
 * [Extensibility](#extensibility)
   * [addFunction](#addFunction), [addAggregateFunction](#addAggregateFunction), [addWindowFunction](#addWindowFunction)
 * [Queries](#queries)
@@ -307,6 +308,50 @@ aq.range('colB', 'colE')
 aq.range(2, 5)
 ```
 
+<hr/><a id="matches" href="#matches">#</a>
+<em>aq</em>.<b>matches</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/expr/selection.js)
+
+Select all columns whose names match a pattern. Returns a function-valued selection compatible with [select](verbs/#select).
+
+* *pattern*: A string or [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) pattern to match.
+
+*Examples*
+
+```js
+// contains the string 'col'
+aq.matches('col')
+```
+
+```js
+// has 'a', 'b', or 'c' as the first character (case-insensitve)
+aq.matches(/^[abc]/i)
+```
+
+<hr/><a id="startswith" href="#startswith">#</a>
+<em>aq</em>.<b>startswith</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/expr/selection.js)
+
+Select all columns whose names start with a string. Returns a function-valued selection compatible with [select](verbs/#select).
+
+* *string*: The string to match at the start of the column name.
+
+*Examples*
+
+```js
+aq.startswith('prefix_')
+```
+
+<hr/><a id="endswith" href="#endswith">#</a>
+<em>aq</em>.<b>endswith</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/expr/selection.js)
+
+Select all columns whose names end with a string. Returns a function-valued selection compatible with [select](verbs/#select).
+
+* *string*: The string to match at the end of the column name.
+
+*Examples*
+
+```js
+aq.endswith('_suffix')
+```
 
 <br/>
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -102,7 +102,7 @@ aq.fromArrow(await arrow.Table.from(fetch(url)))
 <hr/><a id="fromCSV" href="#fromCSV">#</a>
 <em>aq</em>.<b>fromCSV</b>(<i>text</i>[, <i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/from-csv.js)
 
-Parse a comma-separated values (CSV) *text* string into a <a href="table">table</a>. Delimiters other than commas, such as tabs or pipes ('\|'), can be specified using the *options* argument.By default, automatic type inference is performed for input values; string values that match the ISO standard date format are parsed into JavaScript Date objects. To disable this behavior, set *options.autoType* to `false`. To perform custom parsing of input column values, use *options.parse*.
+Parse a comma-separated values (CSV) *text* string into a <a href="table">table</a>. Delimiters other than commas, such as tabs or pipes ('\|'), can be specified using the *options* argument. By default, automatic type inference is performed for input values; string values that match the ISO standard date format are parsed into JavaScript Date objects. To disable this behavior set *options.autoType* to `false`, which will cause all columns to be loaded as strings. To perform custom parsing of input column values, use *options.parse*.
 
  * *text*: A string in a delimited-value format.
  * *options*: A CSV format options object:
@@ -117,6 +117,12 @@ Parse a comma-separated values (CSV) *text* string into a <a href="table">table<
 // create table from an input CSV string
 // akin to table({ a: [1, 3], b: [2, 4] })
 aq.fromCSV('a,b\n1,2\n3,4')
+```
+
+```js
+// override autoType with custom parser for column 'a'
+// akin to table({ a: ['00152', '30219'], b: [2, 4] })
+aq.fromCSV('a,b\n00152,2\n30219,4', { parse: { a: String } })
 ```
 
 ```js

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -640,30 +640,32 @@ Returns an array of a given *object*'s own enumerable property values.
 Recodes an input *value* to an alternative value, based on a provided value *map* object. If a *fallback* value is specified, it will be returned when the input value is not found in the map; otherwise, the input value is returned unchanged.
 
 * *value*: The value to recode. The value must be safely coercible to a string for lookup against the value map.
-* *map*: An object with input values for keys and recoded values for values. Only the object's own properties will be considered; inherited properties on the prototype chain are ignored.
+* *map*: An object or [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) with input values for keys and recoded values for values. If a non-Map object, only the object's own properties will be considered; inherited properties on the prototype chain are ignored.
 * *fallback*: An optional fallback value to use if the input value is not found in the value map. If a fallback is not specified, the input value will be returned unchanged when not found in the map.
 
 *Examples*
 
 ```js
 // recode values in a derive statement
-table.derive({
-  val: d => op.recode(d.val, { 'opt:a': 'A', 'opt:b': 'B' })
-})
+table.derive({ val: d => op.recode(d.val, { 'opt:a': 'A', 'opt:b': 'B' }) })
 ```
 
 ```js
-// define value map externally
-const map = {
-  'opt:a': 'A',
-  'opt:b': 'B'
-};
-
-// bind value map as a parameter
+// define value map externally, bind as parameter
+const map = { 'opt:a': 'A', 'opt:b': 'B' };
 table
   .params({ map })
   .derive({ val: (d, $) => op.recode(d.val, $.map, '?') })
 ```
+
+```js
+// using a Map object, bind as parameter
+const map = new Map().set('opt:a', 'A').set('opt:b', 'B');
+table
+  .params({ map })
+  .derive({ val: (d, $) => op.recode(d.val, $.map, '?') })
+```
+
 
 <br>
 

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -634,6 +634,37 @@ Returns an array of a given *object*'s own enumerable property values.
 
 * *values*: The input object value.
 
+<hr/><a id="recode" href="#recode">#</a>
+<em>op</em>.<b>recode</b>(<i>value</i>, <i>map</i>[, <i>fallback</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/recode.js)
+
+Recodes an input *value* to an alternative value, based on a provided value *map* object. If a *fallback* value is specified, it will be returned when the input value is not found in the map; otherwise, the input value is returned unchanged.
+
+* *value*: The value to recode. The value must be safely coercible to a string for lookup against the value map.
+* *map*: An object with input values for keys and recoded values for values. Only the object's own properties will be considered; inherited properties on the prototype chain are ignored.
+* *fallback*: An optional fallback value to use if the input value is not found in the value map. If a fallback is not specified, the input value will be returned unchanged when not found in the map.
+
+*Examples*
+
+```js
+// recode values in a derive statement
+table.derive({
+  val: d => op.recode(d.val, { 'opt:a': 'A', 'opt:b': 'B' })
+})
+```
+
+```js
+// define value map externally
+const map = {
+  'opt:a': 'A',
+  'opt:b': 'B'
+};
+
+// bind value map as a parameter
+table
+  .params({ map })
+  .derive({ val: (d, $) => op.recode(d.val, $.map, '?') })
+```
+
 <br>
 
 ### <a id="string-functions">String Functions</a>

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -54,7 +54,7 @@ Determines whether an *array* includes a certain *value* among its entries, retu
 
 * *array*: The input array value.
 * *value*: The value to search for.
-* *index*: The integer index to start searcing from (default `0`).
+* *index*: The integer index to start searching from (default `0`).
 
 <hr/><a id="indexof" href="#indexof">#</a>
 <em>op</em>.<b>indexof</b>(<i>sequence</i>, <i>value</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/array.js)

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -190,6 +190,7 @@ Returns an array of objects representing table rows. A new set of objects will b
 
 * *options*: Options for row generation:
   * *limit*: The maximum number of objects to create (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
 
 <hr/><a id="@@iterator" href="#@@iterator">#</a>
 <em>table</em>\[<b>Symbol.iterator</b>\]() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
@@ -216,6 +217,7 @@ Print the contents of this table using the `console.table()` method.
 
 * *options*: Options for printing, typically an object value. If number-valued, the call is equivalent to `{ limit: value }`.
   * *limit*: The maximum number of rows to print (default `10`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
 
 <hr/><a id="toCSV" href="#toCSV">#</a>
 <em>table</em>.<b>toCSV</b>([<i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/to-csv.js)
@@ -225,6 +227,7 @@ Format this table as a comma-separated values (CSV) string. Other delimiters, su
 * *options*: A formatting options object:
   * *delimiter*: The delimiter between values (default `","`).
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to include. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions to invoke to transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
 
@@ -235,6 +238,7 @@ Format this table as an HTML table string.
 
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:
@@ -250,6 +254,7 @@ Format this table as a JavaScript Object Notation (JSON) string.
 
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions to invoke to transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
 
@@ -260,6 +265,7 @@ Format this table as a [GitHub-Flavored Markdown table](https://github.github.co
 
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -240,6 +240,7 @@ Format this table as an HTML table string.
   * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:
     * *date*: One of 'utc' or 'loc' (for UTC or local dates), or `null` for complete date time strings.
     * *digits*: Number of significant digits to include for numbers.
+  * *null*: Optional format function for `null` and `undefined` values. If specified, this function be invoked with the `null` or `undefined` value as the sole input argument. The return value is then used as the HTML output for the input value.
   * *style*: CSS styles to include in HTML output. The object keys can be HTML table tag names: `'table'`, `'thead'`, `'tbody'`, `'tr'`, `'th'`, or `'td'`. The object values should be strings of valid CSS style directives (such as `"font-weight: bold;"`) or functions that take a column name and row as inputs and return a CSS string.
 
 <hr/><a id="toJSON" href="#toJSON">#</a>

--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -59,7 +59,7 @@ Filter a table to a subset of rows based on the input criteria. The resulting ta
 *Examples*
 
 ```js
-table.filter(d => abs(d.value) < 5)
+table.filter(d => op.abs(d.value) < 5)
 ```
 
 <hr/><a id="groupby" href="#groupby">#</a>
@@ -101,15 +101,19 @@ Order table rows based on a set of column values. Subsequent operations sensitiv
 *Examples*
 
 ```js
-table.orderby('a', desc('b'))
+// order by column 'a' in ascending order, than 'b' in descending order
+table.orderby('a', aq.desc('b'))
 ```
 
 ```js
-table.orderby({ a: 'a', b: desc('b') )})
+// same as above, but with object syntax
+// key order is significant, but the key names are ignored
+table.orderby({ a: 'a', b: aq.desc('b') )})
 ```
 
 ```js
-table.orderby(desc(d => d.a))
+// orderby accepts table expressions as well as column names
+table.orderby(aq.desc(d => d.a))
 ```
 
 <hr/><a id="unorder" href="#unorder">#</a>
@@ -134,7 +138,7 @@ Rollup a table to produce an aggregate summary. Often used in conjunction with [
 *Examples*
 
 ```js
-table.groupby('colA').rollup({ mean: d => mean(d.colB) })
+table.groupby('colA').rollup({ mean: d => op.mean(d.colB) })
 ```
 
 ```js
@@ -173,10 +177,12 @@ Generate a table from a random sample of rows. If the table is grouped, perform 
 *Examples*
 
 ```js
+// sample 50 rows without replacement
 table.sample(50)
 ```
 
 ```js
+// sample 100 rows with replacement
 table.sample(100, { replace: true })
 ```
 
@@ -473,7 +479,7 @@ table.fold(['colA', 'colB'])
 ```
 
 ```js
-table.fold(range(5, 8))
+table.fold(aq.range(5, 8))
 ```
 
 
@@ -501,7 +507,7 @@ table.pivot(['keyA', 'keyB'], ['valueA', 'valueB'])
 ```
 
 ```js
-table.pivot({ key: d => d.key }, { value: d => sum(d.value) })
+table.pivot({ key: d => d.key }, { value: d => op.sum(d.value) })
 ```
 
 
@@ -518,7 +524,7 @@ Spread array elements into a set of new columns. Output columns are named based 
 *Examples*
 
 ```js
-table.spread({ a: split(d.text, '') })
+table.spread({ a: d => op.split(d.text, '') })
 ```
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arquero",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Query processing and transformation of array-backed data tables.",
   "keywords": [
     "data",

--- a/src/format/to-csv.js
+++ b/src/format/to-csv.js
@@ -7,6 +7,7 @@ import isDate from '../util/is-date';
  * @typedef {Object} CSVFormatOptions
  * @property {string} [delimiter=','] The delimiter between values.
  * @property {number} [limit=Infinity] The maximum number of rows to print.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]|Function} [columns] Ordered list of column names
  *  to include. If function-valued, the function should accept a table as
  *  input and return an array of column name strings.
@@ -38,7 +39,7 @@ export default function(table, options = {}) {
   const vals = names.map(formatValue);
   let text = '';
 
-  scan(table, names, options.limit, {
+  scan(table, names, options.limit, options.offset, {
     row() {
       text += vals.join(delim) + '\n';
     },

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -7,6 +7,7 @@ import mapObject from '../util/map-object';
  * Options for HTML formatting.
  * @typedef {Object} HTMLOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
  * @property {Object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
@@ -67,7 +68,7 @@ export default function(table, options = {}) {
     + '</tr></thead>'
     + tag('tbody');
 
-  scan(table, names, options.limit, {
+  scan(table, names, options.limit, options.offset, {
     row(row) {
       r = row;
       text += (++idx ? '</tr>' : '') + tag('tr');

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -18,6 +18,10 @@ import mapObject from '../util/map-object';
  *  If specified, these override the automatically inferred options.
  *  - {string} date One of 'utc' or 'loc' (for UTC or local dates), or null for full date times.
  *  - {number} digits Number of significant digits to include for numbers.
+ * @property {Function} [null] Format function for null and undefined values.
+ *  If specified, this function will be invoked with the null or undefined
+ *  value as the sole input, and the return value will be used as the HTML
+ *  output for the value.
  * @property {Object} [style] CSS styles to include in HTML output.
  *  The object keys should be HTML table tag names: 'table', 'thead',
  *  'tbody', 'tr', 'th', or 'td'. The object values should be strings of
@@ -35,11 +39,16 @@ export default function(table, options = {}) {
   const names = columns(table, options.columns);
   const { align, format } = formats(table, names, options);
   const style = styles(options);
+  const nullish = options.null;
 
   const alignValue = a => a === 'c' ? 'center' : a === 'r' ? 'right' : 'left';
   const escape = s => s.replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+  const baseFormat = (value, opt) => escape(formatValue(value, opt));
+  const formatter = nullish
+    ? (value, opt) => value == null ? nullish(value) : baseFormat(value, opt)
+    : baseFormat;
 
   let r = -1;
   let idx = -1;
@@ -65,7 +74,7 @@ export default function(table, options = {}) {
     },
     cell(value, name) {
       text += tag('td', name)
-        + escape(formatValue(value, format[name]))
+        + formatter(value, format[name])
         + '</td>';
     }
   });

--- a/src/format/to-markdown.js
+++ b/src/format/to-markdown.js
@@ -5,6 +5,7 @@ import { columns, formats, scan } from './util';
  * Options for Markdown formatting.
  * @typedef {Object} MarkdownOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
  * @property {Object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
@@ -37,7 +38,7 @@ export default function(table, options = {}) {
     + names.map(name => alignValue(align[name])).join('|')
     + '|';
 
-  scan(table, names, options.limit, {
+  scan(table, names, options.limit, options.offset, {
     row() {
       text += '\n|';
     },

--- a/src/format/util.js
+++ b/src/format/util.js
@@ -7,10 +7,6 @@ export function columns(table, names) {
     : names || table.columnNames();
 }
 
-export function numRows(table, limit) {
-  return limit !== 0 ? Math.min(limit || Infinity, table.numRows()) : 0;
-}
-
 export function formats(table, names, options) {
   const formatOpt = options.format || {};
   const alignOpt = options.align || {};
@@ -31,18 +27,13 @@ function values(table, columnName) {
   return fn => table.scan(row => fn(column.get(row)));
 }
 
-export function scan(table, names, limit, ctx) {
-  limit = numRows(table, limit);
-  if (limit <= 0) return;
-
+export function scan(table, names, limit, offset, ctx) {
   const n = names.length;
-  let r = 0;
-  table.scan((row, data, stop) => {
+  table.scan(row => {
     ctx.row(row);
     for (let i = 0; i < n; ++i) {
       const name = names[i];
       ctx.cell(table.get(name, row), name, i);
     }
-    if (++r >= limit) stop();
-  }, true);
+  }, true, limit, offset);
 }

--- a/src/op/functions/index.js
+++ b/src/op/functions/index.js
@@ -4,12 +4,14 @@ import date from './date';
 import equal from './equal';
 import math from './math';
 import object from './object';
+import recode from './recode';
 import sequence from './sequence';
 import string from './string';
 
 export default {
   bin,
   equal,
+  recode,
   sequence,
   ...array,
   ...date,

--- a/src/op/functions/recode.js
+++ b/src/op/functions/recode.js
@@ -7,15 +7,18 @@ import has from '../../util/has';
  * is returned unchanged.
  * @param {*} value The value to recode. The value must be safely
  *  coercible to a string for lookup against the value map.
- * @param {object} map An object with input values for keys and output
- *  recoded values as values. Only the object's own properties will
- *  be considered.
+ * @param {object|Map} map An object or Map with input values for keys and
+ *  output recoded values as values. If a non-Map object, only the object's
+ *  own properties will be considered.
  * @param {*} [fallback] A default fallback value to use if the input
  *  value is not found in the value map.
  * @return {*} The recoded value.
  */
 export default function(value, map, fallback) {
-  return has(map, value)
-    ? map[value]
-    : fallback !== undefined ? fallback : value;
+  if (map instanceof Map) {
+    if (map.has(value)) return map.get(value);
+  } else if (has(map, value)) {
+    return map[value];
+  }
+  return fallback !== undefined ? fallback : value;
 }

--- a/src/op/functions/recode.js
+++ b/src/op/functions/recode.js
@@ -1,0 +1,21 @@
+import has from '../../util/has';
+
+/**
+ * Recodes an input value to an alternative value, based on a provided
+ * value map. If a fallback value is specified, it will be returned when
+ * a matching value is not found in the map; otherwise, the input value
+ * is returned unchanged.
+ * @param {*} value The value to recode. The value must be safely
+ *  coercible to a string for lookup against the value map.
+ * @param {object} map An object with input values for keys and output
+ *  recoded values as values. Only the object's own properties will
+ *  be considered.
+ * @param {*} [fallback] A default fallback value to use if the input
+ *  value is not found in the value map.
+ * @return {*} The recoded value.
+ */
+export default function(value, map, fallback) {
+  return has(map, value)
+    ? map[value]
+    : fallback !== undefined ? fallback : value;
+}

--- a/src/query/to-ast.js
+++ b/src/query/to-ast.js
@@ -105,6 +105,7 @@ function astSelection(sel) {
   return sel.all ? { type, operator: 'all' }
     : sel.not ? { type, operator: 'not', arguments: astExprList(sel.not) }
     : sel.range ? { type, operator: 'range', arguments: astExprList(sel.range) }
+    : sel.matches ? { type, operator: 'matches', arguments: sel.matches }
     : error('Invalid input');
 }
 

--- a/src/query/util.js
+++ b/src/query/util.js
@@ -1,4 +1,4 @@
-import { all, desc, field, not, range, rolling } from '../verbs';
+import { all, desc, field, matches, not, range, rolling } from '../verbs';
 import Query from './query';
 import error from '../util/error';
 import isArray from '../util/is-array';
@@ -25,6 +25,7 @@ export function getTable(catalog, ref) {
 export function isSelection(value) {
   return isObject(value) && (
     isArray(value.all) ||
+    isArray(value.matches) ||
     isArray(value.not) ||
     isArray(value.range)
   );
@@ -44,6 +45,7 @@ export function fromObject(value) {
     : isArray(value.verbs) ? Query.from(value)
     : isArray(value.all) ? all()
     : isArray(value.range) ? range(...value.range)
+    : isArray(value.match) ? matches(RegExp(...value.match))
     : isArray(value.not) ? not(value.not.map(toObject))
     : fromExprObject(value);
 }

--- a/src/query/verb.js
+++ b/src/query/verb.js
@@ -128,7 +128,10 @@ export const Verbs = {
                 { name: 'keys', type: ExprList, default: [] }
               ]),
   derive:     createVerb('derive', [
-                { name: 'values', type: ExprObject }
+                { name: 'values', type: ExprObject },
+                { name: 'options', type: Options,
+                  props: { before: SelectionList, after: SelectionList }
+                }
               ]),
   filter:     createVerb('filter', [
                 { name: 'criteria', type: ExprObject }
@@ -138,6 +141,12 @@ export const Verbs = {
               ]),
   orderby:    createVerb('orderby', [
                 { name: 'keys', type: OrderbyKeys }
+              ]),
+  relocate:   createVerb('relocate', [
+                { name: 'columns', type: SelectionList },
+                { name: 'options', type: Options,
+                  props: { before: SelectionList, after: SelectionList }
+                }
               ]),
   rollup:     createVerb('rollup', [
                 { name: 'values', type: ExprObject }
@@ -206,143 +215,3 @@ export const Verbs = {
                 { name: 'tables', type: TableRefList }
               ])
 };
-
-
-// export const Reify = createVerb('reify');
-
-// export const Count = createVerb('count', [
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Dedupe = createVerb('dedupe', [
-//   { name: 'keys', type: ExprList, default: [] }
-// ]);
-
-// export const Derive = createVerb('derive', [
-//   { name: 'values', type: ExprObject }
-// ]);
-
-// export const Filter = createVerb('filter', [
-//   { name: 'criteria', type: ExprObject }
-// ]);
-
-// export const Groupby = createVerb('groupby', [
-//   { name: 'keys', type: ExprList }
-// ]);
-
-// export const Orderby = createVerb('orderby', [
-//   { name: 'keys', type: OrderbyKeys }
-// ]);
-
-// export const Rollup = createVerb('rollup', [
-//   { name: 'values', type: ExprObject }
-// ]);
-
-// export const Sample = createVerb('sample', [
-//   { name: 'size', type: ExprNumber },
-//   { name: 'options', type: Options, props: { weight: Expr } }
-// ]);
-
-// export const Select = createVerb('select', [
-//   { name: 'columns', type: SelectionList }
-// ]);
-
-// export const Ungroup = createVerb('ungroup');
-
-// export const Unorder = createVerb('unorder');
-
-// export const Fold = createVerb('fold', [
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Pivot = createVerb('pivot', [
-//   { name: 'keys', type: ExprList },
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Spread = createVerb('spread', [
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Unroll = createVerb('unroll', [
-//   { name: 'values', type: ExprList },
-//   { name: 'options', type: Options, props: { drop: ExprList } }
-// ]);
-
-// export const Lookup = createVerb('lookup', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys },
-//   { name: 'values', type: ExprList }
-// ]);
-
-// export const Join = createVerb('join', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys },
-//   { name: 'values', type: JoinValues },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Cross = createVerb('cross', [
-//   { name: 'table', type: TableRef },
-//   { name: 'values', type: JoinValues },
-//   { name: 'options', type: Options }
-// ]);
-
-// export const Semijoin = createVerb('semijoin', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys }
-// ]);
-
-// export const Antijoin = createVerb('antijoin', [
-//   { name: 'table', type: TableRef },
-//   { name: 'on', type: JoinKeys }
-// ]);
-
-// export const Concat = createVerb('concat', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// export const Union = createVerb('union', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// export const Intersect = createVerb('intersect', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// export const Except = createVerb('except', [
-//   { name: 'tables', type: TableRefList }
-// ]);
-
-// /**
-//  * A lookup table of verb classes.
-//  */
-// export const Verbs = {
-//   count:     Count,
-//   dedupe:    Dedupe,
-//   derive:    Derive,
-//   filter:    Filter,
-//   groupby:   Groupby,
-//   orderby:   Orderby,
-//   rollup:    Rollup,
-//   sample:    Sample,
-//   select:    Select,
-//   ungroup:   Ungroup,
-//   unorder:   Unorder,
-//   fold:      Fold,
-//   pivot:     Pivot,
-//   spread:    Spread,
-//   unroll:    Unroll,
-//   lookup:    Lookup,
-//   join:      Join,
-//   cross:     Cross,
-//   semijoin:  Semijoin,
-//   antijoin:  Antijoin,
-//   concat:    Concat,
-//   union:     Union,
-//   intersect: Intersect,
-//   except:    Except
-// };

--- a/src/table/bit-set.js
+++ b/src/table/bit-set.js
@@ -57,6 +57,12 @@ export default class BitSet {
     return -1;
   }
 
+  nth(n) {
+    let i = this.next(0);
+    while (n-- && i >= 0) i = this.next(i + 1);
+    return i;
+  }
+
   not() {
     const bits = this._bits;
     const n = bits.length;

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -2,7 +2,6 @@ import Column from './column';
 import columnsFrom from './columns-from';
 import Table from './table';
 import { regroup, reindex } from './regroup';
-import { numRows } from '../format/util';
 import toCSV from '../format/to-csv';
 import toHTML from '../format/to-html';
 import toJSON from '../format/to-json';
@@ -111,17 +110,11 @@ export default class ColumnTable extends Table {
    * @return {Array} An array of row objects.
    */
   objects(options = {}) {
-    const limit = numRows(this, options.limit);
-    if (limit <= 0) return [];
-    const tuples = Array(limit);
     const create = rowObjectBuilder(this);
-
-    let r = 0;
-    this.scan((row, data, stop) => {
-      tuples[r] = create(row);
-      if (++r >= limit) stop();
-    }, true);
-
+    const tuples = [];
+    this.scan(row => {
+      tuples.push(create(row));
+    }, true, options.limit, options.offset);
     return tuples;
   }
 

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -439,15 +439,23 @@ export default class Table {
   }
 
   /**
-   * Derive new column values based on the provided expressions.
+   * Derive new column values based on the provided expressions. By default,
+   * new columns are added after (higher indices than) existing columns. Use
+   * the before or after options to place new columns elsewhere.
    * @param {Object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
+   * @param {RelocateOptions} options Options for relocating derived columns.
+   *  Use either a before or after property to indicate where to place
+   *  derived columns. Specifying both before and after is an error. Unlike
+   *  the relocate verb, this option affects only new columns; updated
+   *  columns with existing names are excluded from relocation.
    * @return {Table} A new table with derived columns added.
    * @example table.derive({ sumXY: d => d.x + d.y })
+   * @example table.derive({ z: d => d.x * d.y }, { before: 'x' })
    */
-  derive(values) {
-    return this.__derive(this, values);
+  derive(values, options) {
+    return this.__derive(this, values, options);
   }
 
   /**
@@ -520,6 +528,45 @@ export default class Table {
    */
   reduce(reducer) {
     return this.__reduce(this, reducer);
+  }
+
+  /**
+   * Options for relocate transformations.
+   * @typedef {Object} RelocateOptions
+   * @property {string|string[]|number|number[]|Object|Function} [before]
+   *  An anchor column that relocated columns should be placed before.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the first column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   * @property {string|string[]|number|number[]|Object|Function} [after]
+   *  An anchor column that relocated columns should be placed after.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the last column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   */
+
+  /**
+   * Relocate a subset of columns to change their positions, also
+   * potentially renaming them.
+   * @param {string|string[]|number|number[]|Object|Function} columns An
+   * ordered selection of columns to relocate. The input may consist of:
+   *  - column name strings,
+   *  - column integer indices,
+   *  - objects with current column names as keys and new column names as
+   *    values (for renaming), or
+   *  - functions that take a table as input and returns a valid selection
+   *    parameter (typically the output of the selection helper functions
+   *    {@link all}, {@link not}, or {@link range}).
+   * @param {RelocateOptions} options Options for relocating. Must include
+   *  either the before or after property to indicate where to place the
+   *  relocated columns. Specifying both before and after is an error.
+   * @return {Table} A new table with relocated columns.
+   * @example table.relocate(['colY', 'colZ'], { after: 'colX' })
+   * @example table.relocate(not('colB', 'colC'), { before: 'colA' })
+   * @example table.relocate({ colA: 'newA', colB: 'newB' }, { after: 'colC' })
+   */
+  relocate(columns, options) {
+    return this.__relocate(this, columns, options);
   }
 
   /**

--- a/src/util/escape-regexp.js
+++ b/src/util/escape-regexp.js
@@ -1,0 +1,3 @@
+export default function(str) {
+  return str.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/verbs/derive.js
+++ b/src/verbs/derive.js
@@ -1,6 +1,14 @@
+import relocate from './relocate';
 import _derive from '../engine/derive';
 import parse from '../expression/parse';
 
-export default function(table, values) {
-  return _derive(table, parse(values, { table }));
+export default function(table, values, options = {}) {
+  const dt = _derive(table, parse(values, { table }));
+
+  return options.before == null && options.after == null
+    ? dt
+    : relocate(dt,
+        Object.keys(values).filter(name => table.columnIndex(name) >= 0),
+        options
+      );
 }

--- a/src/verbs/expr/selection.js
+++ b/src/verbs/expr/selection.js
@@ -5,6 +5,7 @@ import isFunction from '../../util/is-function';
 import isObject from '../../util/is-object';
 import isNumber from '../../util/is-number';
 import isString from '../../util/is-string';
+import toString from '../../util/to-string';
 
 export default function resolve(table, sel, map = {}) {
   sel = isNumber(sel) ? table.columnName(sel) : sel;
@@ -18,7 +19,7 @@ export default function resolve(table, sel, map = {}) {
   } else if (isObject(sel)) {
     Object.assign(map, sel);
   } else {
-    error(`Invalid column selection: ${sel+''}`);
+    error(`Invalid column selection: ${toString(sel)}`);
   }
 
   return map;

--- a/src/verbs/expr/selection.js
+++ b/src/verbs/expr/selection.js
@@ -1,4 +1,5 @@
 import error from '../../util/error';
+import escapeRegExp from '../../util/escape-regexp';
 import isArray from '../../util/is-array';
 import isFunction from '../../util/is-function';
 import isObject from '../../util/is-object';
@@ -80,4 +81,35 @@ export function range(start, end) {
     },
     () => ({ range: [start, end] })
   );
+}
+
+/**
+ * Select all columns whose names match a pattern.
+ * @param {string|RegExp} pattern A string or regular expression pattern to match.
+ * @return {Function} Selection function compatible with {@link Table#select}.
+ */
+export function matches(pattern) {
+  if (isString(pattern)) pattern = RegExp(escapeRegExp(pattern));
+  return decorate(
+    table => table.columnNames().filter(name => pattern.test(name)),
+    () => ({ matches: [pattern.source, pattern.flags] })
+  );
+}
+
+/**
+ * Select all columns whose names start with a string.
+ * @param {string} string The string to match at the start of the column name.
+ * @return {Function} Selection function compatible with {@link Table#select}.
+ */
+export function startswith(string) {
+  return matches(RegExp('^' + escapeRegExp(string)));
+}
+
+/**
+ * Select all columns whose names end with a string.
+ * @param {string} string The string to match at the end of the column name.
+ * @return {Function} Selection function compatible with {@link Table#select}.
+ */
+export function endswith(string) {
+  return matches(RegExp(escapeRegExp(string) + '$'));
 }

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -8,6 +8,7 @@ import __join from './join';
 import __join_filter from './join-filter';
 import __lookup from './lookup';
 import __pivot from './pivot';
+import __relocate from './relocate';
 import __rollup from './rollup';
 import __sample from './sample';
 import __select from './select';
@@ -37,6 +38,7 @@ Object.assign(ColumnTable.prototype, {
   __join_filter,
   __lookup,
   __pivot,
+  __relocate,
   __rollup,
   __sample,
   __select,

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -55,7 +55,9 @@ export { default as bin } from './expr/bin';
 export { default as desc } from './expr/desc';
 export { default as field } from './expr/field';
 export { default as rolling } from './expr/rolling';
-export { all, not, range } from './expr/selection';
+export {
+  all, endswith, matches, not, range, startswith
+} from './expr/selection';
 
 /**
  * Create a new table for a set of named columns.

--- a/src/verbs/relocate.js
+++ b/src/verbs/relocate.js
@@ -1,0 +1,38 @@
+import _select from '../engine/select';
+import resolve from './expr/selection';
+import error from '../util/error';
+import has from '../util/has';
+
+export default function(table, columns, { before, after } = {}) {
+  const bef = before != null;
+  const aft = after != null;
+
+  if (!(bef || aft)) {
+    error('relocate requires a before or after option.');
+  }
+  if (bef && aft) {
+    error('relocate accepts only one of the before or after options.');
+  }
+
+  columns = resolve(table, columns);
+  const anchors = Object.keys(resolve(table, bef ? before : after));
+  const anchor = bef ? anchors[0] : anchors.pop();
+  const _cols = {};
+
+  // marshal inputs to select in desired order
+  table.columnNames().forEach(name => {
+    // check if we should assign the current column
+    const assign = !has(columns, name);
+
+    // at anchor column, insert relocated columns
+    if (name === anchor) {
+      if (bef && assign) _cols[name] = name;
+      Object.assign(_cols, columns);
+      if (bef) return; // exit if current column has been handled
+    }
+
+    if (assign) _cols[name] = name;
+  });
+
+  return _select(table, _cols);
+}

--- a/test/format/html-test.js
+++ b/test/format/html-test.js
@@ -103,3 +103,29 @@ tape('toHTML formats html table text with style option', t => {
 
   t.end();
 });
+
+tape('toHTML formats html table text with null option', t => {
+  const a = 'style="text-align: right;"';
+  const html = (a) => [
+    '<table><thead>',
+    '<tr><th>u</th></tr>',
+    '</thead><tbody>',
+    `<tr><td ${a}>a</td></tr>`,
+    `<tr><td ${a}>0</td></tr>`,
+    `<tr><td ${a}><span class="null">null</span></td></tr>`,
+    `<tr><td ${a}><span class="null">undefined</span></td></tr>`,
+    '</tbody></table>'
+  ];
+
+  const dt = new ColumnTable({ u: ['a', 0, null, undefined] });
+
+  t.equal(
+    toHTML(dt, {
+      null: v => `<span class="null">${v}</span>`
+    }),
+    html(a).join(''),
+    'html text with custom null format'
+  );
+
+  t.end();
+});

--- a/test/query/query-builder-test.js
+++ b/test/query/query-builder-test.js
@@ -2,6 +2,8 @@ import tape from 'tape';
 import { desc, not, op } from '../../src/verbs';
 import { field, func } from './util';
 import { query } from '../../src/query/query-builder';
+import { Verbs } from '../../src/query/verb';
+import isFunction from '../../src/util/is-function';
 
 tape('query builder builds single-table queries', t => {
   const q = query()
@@ -14,7 +16,8 @@ tape('query builder builds single-table queries', t => {
     verbs: [
       {
         verb: 'derive',
-        values: { bar: func('d => d.foo + 1') }
+        values: { bar: func('d => d.foo + 1') },
+        options: undefined
       },
       {
         verb: 'rollup',
@@ -99,5 +102,16 @@ tape('query builder supports multi-table queries', t => {
     ]
   }, 'serialized query from builder');
 
+  t.end();
+});
+
+tape('query builder supports all defined verbs', t => {
+  const verbs = Object.keys(Verbs);
+  const q = query();
+  t.equal(
+    verbs.filter(v => isFunction(q[v])).length,
+    verbs.length,
+    'query builder supports all verbs'
+  );
   t.end();
 });

--- a/test/query/verb-test.js
+++ b/test/query/verb-test.js
@@ -9,7 +9,7 @@ import { field, func } from './util';
 const {
   count, dedupe, derive, filter, groupby, orderby,
   reify, rollup, sample, select, ungroup, unorder,
-  pivot, unroll, join, concat
+  relocate, pivot, unroll, join, concat
 } = Verbs;
 
 function test(t, verb, expect, msg) {
@@ -67,11 +67,16 @@ tape('dedupe verb serializes to object', t => {
 });
 
 tape('derive verb serializes to object', t => {
-  const verb = derive({
-    foo: 'd.bar * 5',
-    bar: d => d.foo + 1,
-    baz: rolling(d => op.mean(d.foo), [-3, 3])
-  });
+  const verb = derive(
+    {
+      foo: 'd.bar * 5',
+      bar: d => d.foo + 1,
+      baz: rolling(d => op.mean(d.foo), [-3, 3])
+    },
+    {
+      before: 'bop'
+    }
+  );
 
   test(t,
     verb,
@@ -84,6 +89,9 @@ tape('derive verb serializes to object', t => {
           'd => op.mean(d.foo)',
           { window: { frame: [ -3, 3 ], peers: false } }
         )
+      },
+      options: {
+        before: 'bop'
       }
     },
     'serialized derive verb'
@@ -178,6 +186,30 @@ tape('reify verb serializes to AST', t => {
     verb,
     { verb: 'reify' },
     'serialized reify verb'
+  );
+
+  t.end();
+});
+
+tape('relocate verb serializes to object', t => {
+  test(t,
+    relocate(['foo', 'bar'], { before: 'baz' }),
+    {
+      verb: 'relocate',
+      columns: ['foo', 'bar'],
+      options: { before: 'baz' }
+    },
+    'serialized relocate verb'
+  );
+
+  test(t,
+    relocate(not('foo'), { after: range('a', 'b') }),
+    {
+      verb: 'relocate',
+      columns: { not: ['foo'] },
+      options: { after: { range: ['a', 'b'] } }
+    },
+    'serialized relocate verb'
   );
 
   t.end();

--- a/test/query/verb-test.js
+++ b/test/query/verb-test.js
@@ -1,7 +1,9 @@
 import tape from 'tape';
 import { query } from '../../src/query/query-builder';
 import { Verb, Verbs } from '../../src/query/verb';
-import { all, bin, desc, not, op, range, rolling } from '../../src/verbs';
+import {
+  all, bin, desc, endswith, matches, not, op, range, rolling, startswith
+} from '../../src/verbs';
 import { field, func } from './util';
 
 const {
@@ -266,7 +268,11 @@ tape('select verb serializes to object', t => {
     all(),
     range(0, 1),
     range('a', 'b'),
-    not('foo', 'bar', range(0, 1), range('a', 'b'))
+    not('foo', 'bar', range(0, 1), range('a', 'b')),
+    matches('foo.bar'),
+    matches(/a|b/i),
+    startswith('foo.'),
+    endswith('.baz')
   ]);
 
   test(t,
@@ -287,7 +293,11 @@ tape('select verb serializes to object', t => {
             { range: [0, 1] },
             { range: ['a', 'b'] }
           ]
-        }
+        },
+        { matches: ['foo\\.bar', ''] },
+        { matches: ['a|b', 'i'] },
+        { matches: ['^foo\\.', ''] },
+        { matches: ['\\.baz$', ''] }
       ]
     },
     'serialized select verb'

--- a/test/query/verb-to-ast-test.js
+++ b/test/query/verb-to-ast-test.js
@@ -1,7 +1,9 @@
 import tape from 'tape';
 import { query } from '../../src/query/query-builder';
 import { Verbs } from '../../src/query/verb';
-import { all, bin, desc, not, op, range, rolling } from '../../src/verbs';
+import {
+  all, bin, desc, endswith, matches, not, op, range, rolling, startswith
+} from '../../src/verbs';
 
 const {
   count, dedupe, derive, filter, groupby, orderby,
@@ -355,7 +357,11 @@ tape('select verb serializes to AST', t => {
     all(),
     range(0, 1),
     range('a', 'b'),
-    not('foo', 'bar', range(0, 1), range('a', 'b'))
+    not('foo', 'bar', range(0, 1), range('a', 'b')),
+    matches('foo.bar'),
+    matches(/a|b/i),
+    startswith('foo.'),
+    endswith('.baz')
   ]);
 
   t.deepEqual(
@@ -408,6 +414,26 @@ tape('select verb serializes to AST', t => {
               ]
             }
           ]
+        },
+        {
+          type: 'Selection',
+          operator: 'matches',
+          arguments: [ 'foo\\.bar', '' ]
+        },
+        {
+          type: 'Selection',
+          operator: 'matches',
+          arguments: [ 'a|b', 'i' ]
+        },
+        {
+          type: 'Selection',
+          operator: 'matches',
+          arguments: [ '^foo\\.', '' ]
+        },
+        {
+          type: 'Selection',
+          operator: 'matches',
+          arguments: [ '\\.baz$', '' ]
         }
       ]
     },

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -227,7 +227,7 @@ tape('derive supports recode function', t => {
   tableEqual(t,
     dt.derive({ x: d => op.recode(d.x, {foo: 'farp', bar: 'borp'}, 'other') }),
     { x: ['farp', 'borp', 'other'] },
-    'derive data, recode inline map'
+    'derive data, recode inline map Object'
   );
 
   const map = {
@@ -239,7 +239,16 @@ tape('derive supports recode function', t => {
     dt.params({ map })
       .derive({ x: (d, $) => op.recode(d.x, $.map) }),
     { x: ['farp', 'borp', 'baz'] },
-    'derive data, recode param map'
+    'derive data, recode param map Object'
+  );
+
+  const map2 = new Map([['foo', 'farp'], ['bar', 'borp']]);
+
+  tableEqual(t,
+    dt.params({ map2 })
+      .derive({ x: (d, $) => op.recode(d.x, $.map2) }),
+    { x: ['farp', 'borp', 'baz'] },
+    'derive data, recode param map Map'
   );
 
   t.end();

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -220,3 +220,27 @@ tape('derive supports bigint values', t => {
 
   t.end();
 });
+
+tape('derive supports recode function', t => {
+  const dt = table({ x: ['foo', 'bar', 'baz'] });
+
+  tableEqual(t,
+    dt.derive({ x: d => op.recode(d.x, {foo: 'farp', bar: 'borp'}, 'other') }),
+    { x: ['farp', 'borp', 'other'] },
+    'derive data, recode inline map'
+  );
+
+  const map = {
+    foo: 'farp',
+    bar: 'borp'
+  };
+
+  tableEqual(t,
+    dt.params({ map })
+      .derive({ x: (d, $) => op.recode(d.x, $.map) }),
+    { x: ['farp', 'borp', 'baz'] },
+    'derive data, recode param map'
+  );
+
+  t.end();
+});

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -29,6 +29,33 @@ tape('derive overwrites existing columns', t => {
   t.end();
 });
 
+tape('derive can relocate new columns', t => {
+  const data = {
+    a: [1, 3, 5, 7],
+    b: [2, 4, 6, 8]
+  };
+
+  tableEqual(t,
+    table(data).derive({ z: d => d.a + d.b }, { before: 'a' }),
+    { z: [3, 7, 11, 15], ...data },
+    'derive data, with before'
+  );
+
+  tableEqual(t,
+    table(data).derive({ z: d => d.a + d.b }, { after: 'a' }),
+    { a: data.a, z: [3, 7, 11, 15], b: data.b },
+    'derive data, with before'
+  );
+
+  tableEqual(t,
+    table(data).derive({ a: d => -d.a, z: d => d.a + d.b }, { after: 'b' }),
+    { a: [-1, -3, -5, -7], b: data.b, z: [3, 7, 11, 15] },
+    'derive data, with after and overwrite'
+  );
+
+  t.end();
+});
+
 tape('derive supports aggregate and window operators', t => {
   const n = 10;
   const k = Array(n);

--- a/test/verbs/relocate-test.js
+++ b/test/verbs/relocate-test.js
@@ -1,0 +1,86 @@
+import tape from 'tape';
+import tableEqual from '../table-equal';
+import { not, range, table } from '../../src/verbs';
+
+tape('relocate repositions columns', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { before: 'b' }),
+    { a, c, b, d },
+    'relocate data, before'
+  );
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { after: 'd' }),
+    { b, d, a, c },
+    'relocate data, after'
+  );
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { before: 'c' }),
+    { b, a, c, d },
+    'relocate data, before self'
+  );
+
+  tableEqual(t,
+    dt.relocate(not('b', 'd'), { after: 'a' }),
+    { a, c, b, d },
+    'relocate data, after self'
+  );
+
+  t.end();
+});
+
+tape('relocate repositions columns using multi-column anchor', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  tableEqual(t,
+    dt.relocate([1, 3], { before: range(2, 3) }),
+    { b, a, c, d },
+    'relocate data, before range'
+  );
+
+  tableEqual(t,
+    dt.relocate([1, 3], { after: range(2, 3) }),
+    { b, d, a, c },
+    'relocate data, after range'
+  );
+
+  t.end();
+});
+
+tape('relocate repositions and renames columns', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  tableEqual(t,
+    dt.relocate({ a: 'e', c: 'f' }, { before: { b: '?' } }),
+    { e: a, f: c, b, d },
+    'relocate data, before plus rename'
+  );
+
+  tableEqual(t,
+    dt.relocate({ a: 'e', c: 'f' }, { after: { b: '?' } }),
+    { b, d, e: a, f: c },
+    'relocate data, after plus rename'
+  );
+
+  t.end();
+});
+
+tape('relocate throws errors for invalid options', t => {
+  const a = [1], b = [2], c = [3], d = [4];
+  const dt = table({ a, b, c, d });
+
+  t.throws(() => dt.relocate(not('b', 'd')), 'missing options');
+  t.throws(() => dt.relocate(not('b', 'd'), {}), 'empty options');
+  t.throws(
+    () => dt.relocate(not('b', 'd'), { before: 'b', after: 'b' }),
+    'over-specified options'
+  );
+
+  t.end();
+});

--- a/test/verbs/select-test.js
+++ b/test/verbs/select-test.js
@@ -1,6 +1,8 @@
 import tape from 'tape';
 import tableEqual from '../table-equal';
-import { all, desc, not, range, table } from '../../src/verbs';
+import {
+  all, desc, endswith, matches, not, range, startswith, table
+} from '../../src/verbs';
 
 tape('select selects a subset of columns', t => {
   const data = {
@@ -116,6 +118,37 @@ tape('select accepts selection helpers', t => {
     table(data).select(not(range(0, 1))).columnNames(),
     ['c'],
     'select not range'
+  );
+
+  t.deepEqual(
+    table(data).select(matches('b')).columnNames(),
+    ['b'],
+    'select match string'
+  );
+
+  t.deepEqual(
+    table(data).select(matches(/A|c/i)).columnNames(),
+    ['a', 'c'],
+    'select match regexp'
+  );
+
+  const data2 = {
+    'foo.bar': [],
+    'foo.baz': [],
+    'bop.bar': [],
+    'bop.baz': []
+  };
+
+  t.deepEqual(
+    table(data2).select(startswith('foo.')).columnNames(),
+    ['foo.bar', 'foo.baz'],
+    'select startswith'
+  );
+
+  t.deepEqual(
+    table(data2).select(endswith('.baz')).columnNames(),
+    ['foo.baz', 'bop.baz'],
+    'select startswith'
   );
 
   t.end();


### PR DESCRIPTION
Changes from [v1.1.1](https://github.com/uwdata/arquero/releases/tag/v1.1.1):

- Add `relocate()` verb for repositioning and renaming columns.
- Add `derive()` verb `before` and `after` options to position new derived columns.
- Add `matches()`, `startswith()`, `endswith()` selection helpers.
- Add `op.recode()` function to map input values to recoded values.
- Add `limit` and `offset` arguments to table `scan()` method.
- Add `List` and `Struct` type support to `fromArrow()`. Extracts nested values to arrays and objects, respectively.
- Add `offset` option for output formats such as `toCSV()`, `toHTML()`, _etc_.
- Add `null` option to `toHTML()` to specialize formatting of null and undefined values.

