### PR TITLE
Support nested Arrow types List and Struct.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -101,7 +101,7 @@ aq.fromArrow(await arrow.Table.from(fetch(url)))
 <hr/><a id="fromCSV" href="#fromCSV">#</a>
 <em>aq</em>.<b>fromCSV</b>(<i>text</i>[, <i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/from-csv.js)
 
-Parse a comma-separated values (CSV) *text* string into a <a href="table">table</a>. Delimiters other than commas, such as tabs or pipes ('\|'), can be specified using the *options* argument.By default, automatic type inference is performed for input values; string values that match the ISO standard date format are parsed into JavaScript Date objects. To disable this behavior, set *options.autoType* to `false`. To perform custom parsing of input column values, use *options.parse*.
+Parse a comma-separated values (CSV) *text* string into a <a href="table">table</a>. Delimiters other than commas, such as tabs or pipes ('\|'), can be specified using the *options* argument. By default, automatic type inference is performed for input values; string values that match the ISO standard date format are parsed into JavaScript Date objects. To disable this behavior set *options.autoType* to `false`, which will cause all columns to be loaded as strings. To perform custom parsing of input column values, use *options.parse*.
 
  * *text*: A string in a delimited-value format.
  * *options*: A CSV format options object:
@@ -116,6 +116,12 @@ Parse a comma-separated values (CSV) *text* string into a <a href="table">table<
 // create table from an input CSV string
 // akin to table({ a: [1, 3], b: [2, 4] })
 aq.fromCSV('a,b\n1,2\n3,4')
+```
+
+```js
+// override autoType with custom parser for column 'a'
+// akin to table({ a: ['00152', '30219'], b: [2, 4] })
+aq.fromCSV('a,b\n00152,2\n30219,4', { parse: { a: String } })
 ```
 
 ```js

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -54,7 +54,7 @@ Determines whether an *array* includes a certain *value* among its entries, retu
 
 * *array*: The input array value.
 * *value*: The value to search for.
-* *index*: The integer index to start searcing from (default `0`).
+* *index*: The integer index to start searching from (default `0`).
 
 <hr/><a id="indexof" href="#indexof">#</a>
 <em>op</em>.<b>indexof</b>(<i>sequence</i>, <i>value</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/array.js)

--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -52,7 +52,7 @@ Filter a table to a subset of rows based on the input criteria. The resulting ta
 *Examples*
 
 ```js
-table.filter(d => abs(d.value) < 5)
+table.filter(d => op.abs(d.value) < 5)
 ```
 
 <hr/><a id="groupby" href="#groupby">#</a>
@@ -94,15 +94,19 @@ Order table rows based on a set of column values. Subsequent operations sensitiv
 *Examples*
 
 ```js
-table.orderby('a', desc('b'))
+// order by column 'a' in ascending order, than 'b' in descending order
+table.orderby('a', aq.desc('b'))
 ```
 
 ```js
-table.orderby({ a: 'a', b: desc('b') )})
+// same as above, but with object syntax
+// key order is significant, but the key names are ignored
+table.orderby({ a: 'a', b: aq.desc('b') )})
 ```
 
 ```js
-table.orderby(desc(d => d.a))
+// orderby accepts table expressions as well as column names
+table.orderby(aq.desc(d => d.a))
 ```
 
 <hr/><a id="unorder" href="#unorder">#</a>
@@ -127,7 +131,7 @@ Rollup a table to produce an aggregate summary. Often used in conjunction with [
 *Examples*
 
 ```js
-table.groupby('colA').rollup({ mean: d => mean(d.colB) })
+table.groupby('colA').rollup({ mean: d => op.mean(d.colB) })
 ```
 
 ```js
@@ -166,10 +170,12 @@ Generate a table from a random sample of rows. If the table is grouped, perform 
 *Examples*
 
 ```js
+// sample 50 rows without replacement
 table.sample(50)
 ```
 
 ```js
+// sample 100 rows with replacement
 table.sample(100, { replace: true })
 ```
 
@@ -429,7 +435,7 @@ table.fold(['colA', 'colB'])
 ```
 
 ```js
-table.fold(range(5, 8))
+table.fold(aq.range(5, 8))
 ```
 
 
@@ -457,7 +463,7 @@ table.pivot(['keyA', 'keyB'], ['valueA', 'valueB'])
 ```
 
 ```js
-table.pivot({ key: d => d.key }, { value: d => sum(d.value) })
+table.pivot({ key: d => d.key }, { value: d => op.sum(d.value) })
 ```
 
 
@@ -474,7 +480,7 @@ Spread array elements into a set of new columns. Output columns are named based 
 *Examples*
 
 ```js
-table.spread({ a: split(d.text, '') })
+table.spread({ a: d => op.split(d.text, '') })
 ```
 
 ```js


### PR DESCRIPTION
- Add `List` and `Struct` type support to `fromArrow()`. Extracts nested values to arrays and objects, respectively.