### PR TITLE
v1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arquero",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Query processing and transformation of array-backed data tables.",
   "keywords": [
     "data",


### PR DESCRIPTION
Changes from [v1.2.1](https://github.com/uwdata/arquero/releases/tag/v1.2.1):

- Fix extraction of nested null values in `fromArrow()`.