### PR TITLE
v1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arquero",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Query processing and transformation of array-backed data tables.",
   "keywords": [
     "data",

--- a/src/op/aggregate-functions.js
+++ b/src/op/aggregate-functions.js
@@ -179,7 +179,7 @@ export default {
   sum: {
     create: () => ({
       init:  s => s.sum = 0,
-      value: s => s.sum,
+      value: s => s.valid ? s.sum : undefined,
       add: (s, v) => isBigInt(v)
         ? (s.sum === 0 ? s.sum = v : s.sum += v)
         : s.sum += +v,

--- a/src/util/to-string.js
+++ b/src/util/to-string.js
@@ -1,7 +1,7 @@
 import isBigInt from './is-bigint';
 
 export default function(v) {
-  return isBigInt(v)
-    ? (v.toString() + 'n')
+  return v === undefined ? v + ''
+    : isBigInt(v) ? v + 'n'
     : JSON.stringify(v);
 }

--- a/test/verbs/rollup-test.js
+++ b/test/verbs/rollup-test.js
@@ -37,6 +37,32 @@ tape('rollup produces grouped aggregates', t => {
   t.end();
 });
 
+tape('rollup handles empty tables', t => {
+  [[], [null, null], [undefined, undefined], [NaN, NaN]].forEach(v => {
+    const rt = table({ v }).rollup({
+      sum:  op.sum('v'),
+      prod: op.product('v'),
+      mode: op.mode('v'),
+      med:  op.median('v'),
+      min:  op.min('v'),
+      max:  op.min('v'),
+      sd:   op.stdev('v')
+    });
+
+    tableEqual(t, rt, {
+      sum:  [undefined],
+      prod: [undefined],
+      mode: [undefined],
+      med:  [undefined],
+      min:  [undefined],
+      max:  [undefined],
+      sd:   [undefined]
+    }, 'rollup data, ' + (v.length ? v[0] : 'empty'));
+  });
+
+  t.end();
+});
+
 tape('rollup supports bigint values', t => {
   const data = {
     v: [1n, 2n, 3n, 4n, 5n]


### PR DESCRIPTION
Changes from [v1.2.2](https://github.com/uwdata/arquero/releases/tag/v1.2.2):

- Consistently handle empty/null input to non-count aggregates, return `undefined`.
- Handle `undefined` input to `toString()`.