### PR TITLE
chore: Add typescript types to build output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "module": "src/index.js",
   "unpkg": "dist/arquero.min.js",
   "jsdelivr": "dist/arquero.min.js",
+  "types": "dist/types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/uwdata/arquero.git"
@@ -24,6 +25,7 @@
   "scripts": {
     "prebuild": "rimraf dist && mkdir dist",
     "build": "rollup -c",
+    "postbuild": "tsc",
     "lint": "yarn eslint src test --ext .js",
     "test": "TZ=America/Los_Angeles tape 'test/**/*-test.js' --require esm",
     "prepublishOnly": "yarn test && yarn lint && yarn build"
@@ -40,6 +42,7 @@
     "rollup": "^2.34.2",
     "rollup-plugin-bundle-size": "1.0.3",
     "rollup-plugin-terser": "^7.0.2",
-    "tape": "^5.0.1"
+    "tape": "^5.0.1",
+    "typescript": "^4.1.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,6 +1330,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+
 uri-js@^4.2.2:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.0.tgz#aa714261de793e8a82347a7bcc9ce74e86f28602"


### PR DESCRIPTION
Opening this PR to start a conversation about supporting TypeScript. This project is close to supporting TypeScript since types can be generated from JSDocs. This PR shows how to generate types for the project and will work as long as the JSDocs are maintained for the public API.

My team and I have been using a local copy of arquero with types generated from the well maintained JSDocs for about two weeks now without any problems. The types align very well with the codebase thanks to the accurate JSDocs. There are few exceptions to this. For example, the JSDocs for `table.filter` states that it expects a `Function` as a param but I believe it actually accepts `Function|string` since `filter` supports table expressions. I am happy to submit PRs for JSDoc updates whenever we find a mismatch between the types and codebase. 