### PR TITLE
Correctly order integer-named columns.

### DIFF
--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -35,7 +35,8 @@ title: Verbs \| Arquero API Reference
 Derive new column values based on the provided expressions.
 
 * *values*: Object of name-value pairs defining the columns to derive. The input object should have output column names for keys and table expressions for values.
-* *options*: An options object for relocating derived columns. Use either the *before* or *after* property to indicate where to place derived columns. Specifying both before and after is an error. Unlike the [relocate](#relocate) verb, this option affects only new columns; overwritten columns with existing names are excluded from relocation.
+* *options*: An options object for dropping or relocating derived columns. Use either the *before* or *after* property to indicate where to place derived columns. Specifying both before and after is an error. Unlike the [relocate](#relocate) verb, this option affects only new columns; overwritten columns with existing names are excluded from relocation.
+  * *drop*: A boolean (default `false`) indicating if the original columns should be dropped, leaving only the derived columns. If `true`, the *before* and *after* options are ignored.
   * *before*: An anchor column that relocated columns should be placed before. The value can be any legal column selection. If multiple columns are selected, only the *first* column will be used as an anchor.
   * *after*: An anchor column that relocated columns should be placed after. The value can be any legal column selection. If multiple columns are selected, only the *last* column will be used as an anchor.
 

--- a/src/engine/concat.js
+++ b/src/engine/concat.js
@@ -1,27 +1,21 @@
-import Column from '../table/column';
+import columnSet from '../table/column-set';
 
 export default function(table, others) {
   if (others.length === 0) return table;
 
   const tables = [table, ...others];
-  const names = table.columnNames();
   const nrows = tables.reduce((n, t) => n + t.numRows(), 0);
-  const data = {};
+  const cols = columnSet();
 
-  names.forEach(name => {
+  table.columnNames().forEach(name => {
     const arr = Array(nrows);
     let row = 0;
     tables.forEach(table => {
       const col = table.column(name) || { get: () => undefined };
       table.scan(trow => arr[row++] = col.get(trow));
     });
-    data[name] = Column.from(arr);
+    cols.add(name, arr);
   });
 
-  return table.create({
-    data,
-    filter: null,
-    groups: null,
-    order:  null
-  });
+  return table.create(cols.new());
 }

--- a/src/engine/fold.js
+++ b/src/engine/fold.js
@@ -1,19 +1,18 @@
 import unroll from './unroll';
 import { aggregateGet } from './reduce/util';
 
-export default function(table, { values = {}, ops = [] }, options = {}) {
-  const keys = Object.keys(values);
-  const n = keys.length;
-  if (n === 0) return table;
+export default function(table, { names = [], exprs = [], ops = [] }, options = {}) {
+  if (names.length === 0) return table;
 
-  const as = options.as || [];
-  const vals = aggregateGet(table, ops, Object.values(values));
-  const exprs = {
-    values: {
-      [as[0] || 'key']: () => keys,
-      [as[1] || 'value']: (row, data) => vals.map(fn => fn(row, data))
-    }
-  };
+  const [k = 'key', v = 'value'] = options.as || [];
+  const vals = aggregateGet(table, ops, exprs);
 
-  return unroll(table, exprs, { ...options, drop: values });
+  return unroll(
+    table,
+    {
+      names: [k, v],
+      exprs: [() => names, (row, data) => vals.map(fn => fn(row, data))]
+    },
+    { ...options, drop: names }
+  );
 }

--- a/src/engine/groupby.js
+++ b/src/engine/groupby.js
@@ -7,12 +7,11 @@ export default function(table, exprs) {
   });
 }
 
-function createGroups(table, { values = {}, ops = [] }) {
+function createGroups(table, { names = [], exprs = [], ops = [] }) {
   const data = table.data();
-  const names = Object.keys(values);
   if (names.length === 0) return null;
 
-  let get = aggregateGet(table, ops, Object.values(values));
+  let get = aggregateGet(table, ops, exprs);
   const getKey = keyFunction(get);
   const keys = new Uint32Array(table.totalRows());
   const index = {};

--- a/src/engine/lookup.js
+++ b/src/engine/lookup.js
@@ -1,11 +1,11 @@
 import { aggregateGet } from './reduce/util';
+import columnSet from '../table/column-set';
 
-export default function(tableL, tableR, [keyL, keyR], { values, ops }) {
+export default function(tableL, tableR, [keyL, keyR], { names, exprs, ops }) {
   // instantiate output data
-  const data = { ...tableL.columns() };
-  const names = Object.keys(values);
+  const cols = columnSet(tableL);
   const total = tableL.totalRows();
-  names.forEach(name => data[name] = Array(total));
+  names.forEach(name => cols.add(name, Array(total)));
 
   // build lookup table
   const lut = new Map();
@@ -29,11 +29,11 @@ export default function(tableL, tableR, [keyL, keyR], { values, ops }) {
 
   // output values for matching rows
   const dataR = tableR.data();
-  const get = aggregateGet(tableR, ops, Object.values(values));
+  const get = aggregateGet(tableR, ops, exprs);
   const n = get.length;
 
   for (let i = 0; i < n; ++i) {
-    const column = data[names[i]];
+    const column = cols.data[names[i]];
     const getter = get[i];
     for (let j = 0; j < m; ++j) {
       const rrow = rowR[j];
@@ -41,5 +41,5 @@ export default function(tableL, tableR, [keyL, keyR], { values, ops }) {
     }
   }
 
-  return tableL.create({ data });
+  return tableL.create(cols);
 }

--- a/src/engine/reduce.js
+++ b/src/engine/reduce.js
@@ -1,34 +1,31 @@
 import { groupInit, groupOutput, reduceFlat, reduceGroups } from './reduce/util';
+import columnSet from '../table/column-set';
 
 export default function(table, reducer) {
-  const data = {};
+  const cols = columnSet();
 
   if (table.isGrouped()) {
     const groups = table.groups();
-    const counts = groupInit(data, table);
+    const counts = groupInit(cols, table);
     output(
       reduceGroups(table, reducer, groups),
-      reducer, data, counts
+      reducer, cols, counts
     );
-    groupOutput(data, table, counts);
+    groupOutput(cols.data, table, counts);
   } else {
     output(
       reduceFlat(table, reducer),
-      reducer, data
+      reducer, cols
     );
   }
 
-  return table.create({
-    data,
-    filter: null,
-    groups: null,
-    order: null
-  });
+  return table.create(cols.new());
 }
 
-function output(cells, reducer, data, counts) {
+function output(cells, reducer, cols, counts) {
   // initialize output columns
-  reducer.outputs().map(name => data[name] = []);
+  reducer.outputs().map(name => cols.add(name, []));
+  const { data } = cols;
 
   // write aggregate values to output columns
   if (counts) {

--- a/src/engine/reduce/util.js
+++ b/src/engine/reduce/util.js
@@ -92,11 +92,11 @@ export function reduceGroups(table, reducer, groups) {
   return cells;
 }
 
-export function groupInit(data, table) {
+export function groupInit(cols, table) {
   const { names, size } = table.groups();
 
   // initialize group output columns
-  names.forEach(name => data[name] = Array(size));
+  names.forEach(name => cols.add(name, Array(size)));
 
   // return empty row count array
   return new Uint32Array(size + 1);

--- a/src/engine/select.js
+++ b/src/engine/select.js
@@ -1,16 +1,17 @@
+import columnSet from '../table/column-set';
 import error from '../util/error';
 import isString from '../util/is-string';
 
 export default function(table, columns) {
-  const data = {};
+  const cols = columnSet();
 
-  for (const curr in columns) {
-    const value = columns[curr];
+  columns.forEach((value, curr) => {
     const next = isString(value) ? value : curr;
     if (next) {
-      data[next] = table.column(curr) || error(`Unrecognized column: ${curr}`);
+      const col = table.column(curr) || error(`Unrecognized column: ${curr}`);
+      cols.add(next, col);
     }
-  }
+  });
 
-  return table.create({ data });
+  return table.create(cols);
 }

--- a/src/engine/spread.js
+++ b/src/engine/spread.js
@@ -1,24 +1,24 @@
 import { aggregateGet } from './reduce/util';
+import columnSet from '../table/column-set';
 import toArray from '../util/to-array';
 
-export default function(table, { values = {}, ops = [] }, options = {}) {
+export default function(table, { names, exprs, ops = [] }, options = {}) {
   const limit = options.limit > 0 ? +options.limit : Infinity;
-  const names = Object.keys(values);
   if (names.length === 0) return table;
 
   const as = (names.length === 1 && options.as) || [];
-  const get = aggregateGet(table, ops, Object.values(values));
-  const data = { ...table.data() };
+  const get = aggregateGet(table, ops, exprs);
+  const cols = columnSet(table);
 
   names.forEach((name, index) => {
     const columns = spread(table, get[index], limit);
     const n = columns.length;
     for (let i = 0; i < n; ++i) {
-      data[as[i] || `${name}${i + 1}`] = columns[i];
+      cols.add(as[i] || `${name}${i + 1}`, columns[i]);
     }
   });
 
-  return table.create({ data });
+  return table.create(cols);
 }
 
 function spread(table, get, limit) {

--- a/src/query/query-builder.js
+++ b/src/query/query-builder.js
@@ -124,15 +124,33 @@ export default class QueryBuilder extends Query {
   }
 
   /**
+   * Options for relocate transformations.
+   * @typedef {Object} DeriveOptions
+   * @property {boolean} [drop=false] A flag indicating if the original
+   *  columns should be dropped, leaving only the derived columns. If true,
+   *  the before and after options are ignored.
+   * @property {string|string[]|number|number[]|Object|Function} [before]
+   *  An anchor column that relocated columns should be placed before.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the first column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   * @property {string|string[]|number|number[]|Object|Function} [after]
+   *  An anchor column that relocated columns should be placed after.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the last column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   */
+
+  /**
    * Derive new column values based on the provided expressions.
    * @param {Object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
-   * @param {RelocateOptions=} options Options for relocating derived columns.
-   *  Use either a before or after property to indicate where to place
-   *  derived columns. Specifying both before and after is an error. Unlike
-   *  the relocate verb, this option affects only new columns; updated
-   *  columns with existing names are excluded from relocation.
+   * @param {DeriveOptions=} options Options for dropping or relocating
+   *  derived columns. Use either a before or after property to indicate
+   *  where to place derived columns. Specifying both before and after is an
+   *  error. Unlike the relocate verb, this option affects only new columns;
+   *  updated columns with existing names are excluded from relocation.
    * @return {QueryBuilder} A new builder with "derive" verb appended.
    * @example query.derive({ sumXY: d => d.x + d.y })
    * @example query.derive({ z: d => d.x * d.y }, { before: 'x' })

--- a/src/query/to-ast.js
+++ b/src/query/to-ast.js
@@ -59,7 +59,7 @@ function astOptions(value, types = {}) {
 }
 
 function astParse(expr, opt) {
-  return parse({ expr }, { ...opt, ast: true }).expr;
+  return parse({ expr }, { ...opt, ast: true }).exprs[0];
 }
 
 function astColumn(name) {

--- a/src/table/column-set.js
+++ b/src/table/column-set.js
@@ -1,0 +1,30 @@
+import has from '../util/has';
+
+export default function(table) {
+  return table
+    ? new ColumnSet({ ...table.data() }, table.columnNames())
+    : new ColumnSet();
+}
+
+class ColumnSet {
+  constructor(data, names) {
+    this.data = data || {};
+    this.names = names || [];
+  }
+
+  add(name, values) {
+    if (!this.has(name)) this.names.push(name + '');
+    return this.data[name] = values;
+  }
+
+  has(name) {
+    return has(this.data, name);
+  }
+
+  new() {
+    this.filter = null;
+    this.groups = null;
+    this.order = null;
+    return this;
+  }
+}

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -33,14 +33,14 @@ export default class ColumnTable extends Table {
     return new ColumnTable(columnsFrom(values, names));
   }
 
-  constructor(columns, filter, group, order, params) {
+  constructor(columns, filter, group, order, params, names) {
     mapObject(columns, Column.from, columns);
-    const names = Object.keys(columns);
+    names = names || Object.keys(columns);
     const nrows = names.length ? columns[names[0]].length : 0;
     super(names, nrows, columns, filter, group, order, params);
   }
 
-  create({ data, filter, groups, order }) {
+  create({ data, names, filter, groups, order }) {
     const f = filter
       ? (this._filter ? this._filter.and(filter) : filter)
       : filter !== undefined ? filter : this._filter;
@@ -50,7 +50,8 @@ export default class ColumnTable extends Table {
       f,
       groups !== undefined ? groups : regroup(this._group, filter && f),
       order !== undefined ? order : this._order,
-      this._params
+      this._params,
+      names || (!data ? this._names : null)
     );
   }
 

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -49,13 +49,14 @@ export default class Table {
    * setting is not specified, it is inherited from the current table.
    * @param {Object} [config] Configuration settings for the new table:
    *  - data: The data payload to use.
+   *  - names: An ordered list of column names.
    *  - filter: An additional filter bitset to apply.
    *  - groups: The groupby specification to use (null for no groups).
    *  - order: The orderby comparator to use (null for no order).
    *  - params: Table expression parameters.
    * @return {Table} A newly created table.
    */
-  create({ data, filter, groups, order }) { // eslint-disable-line no-unused-vars
+  create({ data, names, filter, groups, order }) { // eslint-disable-line no-unused-vars
   }
 
   /**
@@ -439,17 +440,35 @@ export default class Table {
   }
 
   /**
+   * Options for relocate transformations.
+   * @typedef {Object} DeriveOptions
+   * @property {boolean} [drop=false] A flag indicating if the original
+   *  columns should be dropped, leaving only the derived columns. If true,
+   *  the before and after options are ignored.
+   * @property {string|string[]|number|number[]|Object|Function} [before]
+   *  An anchor column that relocated columns should be placed before.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the first column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   * @property {string|string[]|number|number[]|Object|Function} [after]
+   *  An anchor column that relocated columns should be placed after.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the last column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   */
+
+  /**
    * Derive new column values based on the provided expressions. By default,
    * new columns are added after (higher indices than) existing columns. Use
    * the before or after options to place new columns elsewhere.
    * @param {Object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
-   * @param {RelocateOptions=} options Options for relocating derived columns.
-   *  Use either a before or after property to indicate where to place
-   *  derived columns. Specifying both before and after is an error. Unlike
-   *  the relocate verb, this option affects only new columns; updated
-   *  columns with existing names are excluded from relocation.
+   * @param {DeriveOptions=} options Options for dropping or relocating
+   *  derived columns. Use either a before or after property to indicate
+   *  where to place derived columns. Specifying both before and after is an
+   *  error. Unlike the relocate verb, this option affects only new columns;
+   *  updated columns with existing names are excluded from relocation.
    * @return {Table} A new table with derived columns added.
    * @example table.derive({ sumXY: d => d.x + d.y })
    * @example table.derive({ z: d => d.x * d.y }, { before: 'x' })

--- a/src/util/assign.js
+++ b/src/util/assign.js
@@ -1,0 +1,8 @@
+import entries from './entries';
+
+export default function(map, pairs) {
+  for (const [key, value] of entries(pairs)) {
+    map.set(key, value);
+  }
+  return map;
+}

--- a/src/util/entries.js
+++ b/src/util/entries.js
@@ -1,0 +1,8 @@
+import isArray from './is-array';
+import isMap from './is-map';
+
+export default function(value) {
+  return isArray(value) ? value
+    : isMap(value) ? value.entries()
+    : Object.entries(value);
+}

--- a/src/util/is-function.js
+++ b/src/util/is-function.js
@@ -1,3 +1,3 @@
-export default function isFunction(value) {
+export default function(value) {
   return typeof value === 'function';
 }

--- a/src/util/is-map.js
+++ b/src/util/is-map.js
@@ -1,3 +1,3 @@
 export default function(value) {
-  return value === Object(value);
+  return value instanceof Map;
 }

--- a/src/util/is-string.js
+++ b/src/util/is-string.js
@@ -1,3 +1,3 @@
-export default function isString(value) {
+export default function(value) {
   return typeof value === 'string';
 }

--- a/src/util/is-valid.js
+++ b/src/util/is-valid.js
@@ -1,3 +1,3 @@
-export default function isValid(value) {
+export default function(value) {
   return value != null && value === value;
 }

--- a/src/verbs/derive.js
+++ b/src/verbs/derive.js
@@ -3,12 +3,12 @@ import _derive from '../engine/derive';
 import parse from '../expression/parse';
 
 export default function(table, values, options = {}) {
-  const dt = _derive(table, parse(values, { table }));
+  const dt = _derive(table, parse(values, { table }), options);
 
-  return options.before == null && options.after == null
+  return options.drop || (options.before == null && options.after == null)
     ? dt
     : relocate(dt,
-        Object.keys(values).filter(name => table.columnIndex(name) < 0),
+        Object.keys(values).filter(name => !table.column(name)),
         options
       );
 }

--- a/src/verbs/expr/parse-key.js
+++ b/src/verbs/expr/parse-key.js
@@ -9,15 +9,15 @@ import keyFunction from '../../util/key-function';
 import toArray from '../../util/to-array';
 
 export default function(name, table, params) {
-  const exprs = {};
+  const exprs = new Map();
 
   toArray(params).forEach((param, i) => {
     param = isNumber(param) ? table.columnName(param) : param;
-    isString(param) ? (exprs[i] = field(param))
-      : isFunction(param) || isObject(param) && param.expr ? (exprs[i] = param)
+    isString(param) ? exprs.set(i, field(param))
+      : isFunction(param) || isObject(param) && param.expr ? exprs.set(i, param)
       : error(`Invalid ${name} key value: ${param+''}`);
   });
 
   const fn = parse(exprs, { table, aggregate: false, window: false });
-  return keyFunction(Object.values(fn.values), true);
+  return keyFunction(fn.exprs, true);
 }

--- a/src/verbs/expr/parse.js
+++ b/src/verbs/expr/parse.js
@@ -1,6 +1,7 @@
 import field from './field';
 import resolve from './selection';
 import parse from '../../expression/parse';
+import assign from '../../util/assign';
 import error from '../../util/error';
 import isNumber from '../../util/is-number';
 import isObject from '../../util/is-object';
@@ -9,13 +10,13 @@ import isFunction from '../../util/is-function';
 import toArray from '../../util/to-array';
 
 export default function(name, table, params, options = { window: false }) {
-  const exprs = {};
+  const exprs = new Map();
 
   const marshal = param => {
     param = isNumber(param) ? table.columnName(param) : param;
-    isString(param) ? (exprs[param] = field(param))
-      : isFunction(param) ? Object.keys(resolve(table, param)).forEach(marshal)
-      : isObject(param) ? Object.assign(exprs, param)
+    isString(param) ? exprs.set(param, field(param))
+      : isFunction(param) ? resolve(table, param).forEach(marshal)
+      : isObject(param) ? assign(exprs, param)
       : error(`Invalid ${name} value: ${param+''}`);
   };
 

--- a/src/verbs/expr/selection.js
+++ b/src/verbs/expr/selection.js
@@ -1,3 +1,4 @@
+import assign from '../../util/assign';
 import error from '../../util/error';
 import escapeRegExp from '../../util/escape-regexp';
 import isArray from '../../util/is-array';
@@ -7,17 +8,17 @@ import isNumber from '../../util/is-number';
 import isString from '../../util/is-string';
 import toString from '../../util/to-string';
 
-export default function resolve(table, sel, map = {}) {
+export default function resolve(table, sel, map = new Map()) {
   sel = isNumber(sel) ? table.columnName(sel) : sel;
 
   if (isString(sel)) {
-    map[sel] = sel;
+    map.set(sel, sel);
   } else if (isArray(sel)) {
     sel.forEach(r => resolve(table, r, map));
   } else if (isFunction(sel)) {
     resolve(table, sel(table), map);
   } else if (isObject(sel)) {
-    Object.assign(map, sel);
+    assign(map, sel);
   } else {
     error(`Invalid column selection: ${toString(sel)}`);
   }
@@ -60,7 +61,7 @@ export function not(...selection) {
   return decorate(
     table => {
       const drop = resolve(table, selection);
-      return table.columnNames(name => !drop[name]);
+      return table.columnNames(name => !drop.has(name));
     },
     () => ({ not: toObject(selection) })
   );

--- a/src/verbs/filter.js
+++ b/src/verbs/filter.js
@@ -3,11 +3,11 @@ import _filter from '../engine/filter';
 import parse from '../expression/parse';
 
 export default function(table, criteria) {
-  const expr = parse({ test: criteria }, { table });
-  let { test } = expr.values;
-  if (expr.ops.length) {
-    const bv = _derive(table, expr).column('test');
-    test = row => bv.get(row);
+  const test = parse({ test: criteria }, { table });
+  let predicate = test.exprs[0];
+  if (test.ops.length) {
+    const bv = _derive(table, test, { drop: true }).column('test');
+    predicate = row => bv.get(row);
   }
-  return _filter(table, test);
+  return _filter(table, predicate);
 }

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -71,8 +71,11 @@ export {
  * @return {ColumnTable} the instantiated table
  * @example table({ colA: ['a', 'b', 'c'], colB: [3, 4, 5] })
  */
-export function table(columns) {
-  return new ColumnTable(mapObject(columns, x => x));
+export function table(columns, names) {
+  return new ColumnTable(
+    mapObject(columns, x => x),
+    null, null, null, null, names
+  );
 }
 
 /**

--- a/src/verbs/join-filter.js
+++ b/src/verbs/join-filter.js
@@ -11,7 +11,7 @@ export default function(tableL, tableR, on, options) {
         parseKey('join', tableL, on[0]),
         parseKey('join', tableR, on[1])
       )
-    : parse({ on }, { join: [tableL, tableR] }).values.on;
+    : parse({ on }, { join: [tableL, tableR] }).exprs[0];
 
   return _join_filter(tableL, tableR, on, options);
 }

--- a/src/verbs/orderby.js
+++ b/src/verbs/orderby.js
@@ -12,22 +12,22 @@ export default function(table, values) {
 }
 
 function parseValues(table, params) {
-  const exprs = {};
-
   let index = -1;
+  const exprs = new Map();
+  const add = val => exprs.set(++index + '', val);
+
   params.forEach(param => {
     const expr = param.expr != null ? param.expr : param;
 
     if (isObject(expr) && !isFunction(expr)) {
-      for (const key in expr) {
-        exprs[++index] = expr[key];
-      }
+      for (const key in expr) add(expr[key]);
     } else {
-      param = isNumber(expr) ? field(param, table.columnName(expr))
-        : isString(expr) ? field(param)
-        : isFunction(expr) ? param
-        : error(`Invalid orderby field: ${param+''}`);
-      exprs[++index] = param;
+      add(
+        isNumber(expr) ? field(param, table.columnName(expr))
+          : isString(expr) ? field(param)
+          : isFunction(expr) ? param
+          : error(`Invalid orderby field: ${param+''}`)
+      );
     }
   });
 

--- a/src/verbs/pivot.js
+++ b/src/verbs/pivot.js
@@ -11,12 +11,10 @@ export default function(table, on, values, options) {
   );
 }
 
-function preparse(values) {
+function preparse(map) {
   // map direct field reference to "any" aggregate
-  for (const key in values) {
-    const value = values[key];
-    if (value.field) {
-      values[key] = `d => any(d[${JSON.stringify(value+'')}])`;
-    }
-  }
+  map.forEach((value, key) => value.field
+    ? map.set(key, `d => any(d[${JSON.stringify(value+'')}])`)
+    : 0
+  );
 }

--- a/src/verbs/relocate.js
+++ b/src/verbs/relocate.js
@@ -1,7 +1,6 @@
 import _select from '../engine/select';
 import resolve from './expr/selection';
 import error from '../util/error';
-import has from '../util/has';
 
 export default function(table, columns, { before, after } = {}) {
   const bef = before != null;
@@ -15,24 +14,26 @@ export default function(table, columns, { before, after } = {}) {
   }
 
   columns = resolve(table, columns);
-  const anchors = Object.keys(resolve(table, bef ? before : after));
+  const anchors = [...resolve(table, bef ? before : after).keys()];
   const anchor = bef ? anchors[0] : anchors.pop();
-  const _cols = {};
+  const select = new Map();
 
   // marshal inputs to select in desired order
   table.columnNames().forEach(name => {
     // check if we should assign the current column
-    const assign = !has(columns, name);
+    const assign = !columns.has(name);
 
     // at anchor column, insert relocated columns
     if (name === anchor) {
-      if (aft && assign) _cols[name] = name;
-      Object.assign(_cols, columns);
+      if (aft && assign) select.set(name, name);
+      for (const [key, value] of columns) {
+        select.set(key, value);
+      }
       if (aft) return; // exit if current column has been handled
     }
 
-    if (assign) _cols[name] = name;
+    if (assign) select.set(name, name);
   });
 
-  return _select(table, _cols);
+  return _select(table, select);
 }

--- a/src/verbs/unroll.js
+++ b/src/verbs/unroll.js
@@ -6,7 +6,7 @@ export default function(table, values, options) {
     table,
     parse('unroll', table, values),
     options && options.drop
-      ? { ...options, drop: parse('unroll', table, options.drop).values }
+      ? { ...options, drop: parse('unroll', table, options.drop).names }
       : options
   );
 }

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -22,10 +22,25 @@ tape('derive overwrites existing columns', t => {
     b: [2, 4, 6, 8]
   };
 
-  const dt = table(data).derive({ a: d => d.a + d.b });
-  t.equal(dt.numRows(), 4, 'num rows');
-  t.equal(dt.numCols(), 2, 'num cols');
-  tableEqual(t, dt, { ...data, a: [3, 7, 11, 15] }, 'derive data');
+  tableEqual(t,
+    table(data).derive({ a: d => d.a + d.b }),
+    { ...data, a: [3, 7, 11, 15] },
+    'derive data'
+  );
+  t.end();
+});
+
+tape('derive drops existing columns with option', t => {
+  const data = {
+    a: [1, 3, 5, 7],
+    b: [2, 4, 6, 8]
+  };
+
+  tableEqual(t,
+    table(data).derive({ z: d => d.a + d.b }, { drop: true }),
+    { z: [3, 7, 11, 15] },
+    'derive data'
+  );
   t.end();
 });
 

--- a/test/verbs/pivot-test.js
+++ b/test/verbs/pivot-test.js
@@ -89,3 +89,22 @@ tape('pivot respects input options', t => {
 
   t.end();
 });
+
+tape('pivot correctly orders integer column names', t => {
+  const data = {
+    g: ['a', 'a', 'a', 'b', 'b', 'b'],
+    k: [2002, 2001, 2000, 2002, 2001, 2000],
+    x: [1, 2, 3, 4, 5, 6]
+  };
+
+  const ut = table(data)
+    .groupby('g')
+    .pivot('k', 'x', { sort: false });
+
+  tableEqual(t, ut, {
+    'g': ['a', 'b'], '2002': [ 1, 4 ], '2001': [ 2, 5 ], '2000': [ 3, 6 ]
+  }, 'pivot data');
+
+  t.deepEqual(ut.columnNames(), ['g', '2002', '2001', '2000']);
+  t.end();
+});

--- a/test/verbs/select-test.js
+++ b/test/verbs/select-test.js
@@ -19,6 +19,27 @@ tape('select selects a subset of columns', t => {
   t.end();
 });
 
+tape('select handles columns with numeric names', t => {
+  const data = {
+    country: [0],
+    '1999': [1],
+    '2000': [2]
+  };
+
+  const dt = table(data, ['country', '1999', '2000']);
+  t.deepEqual(
+    dt.columnNames(),
+    ['country', '1999', '2000']
+  );
+
+  t.deepEqual(
+    dt.select('1999', 'country', '2000').columnNames(),
+    ['1999', 'country', '2000']
+  );
+
+  t.end();
+});
+
 tape('select renames columns', t => {
   const data = {
     a: [1, 3, 5, 7],


### PR DESCRIPTION
- Fix internal column name handling to properly order integer-named columns.
- Add boolean `drop` option for `derive()` verb.

Fix #53.