### PR TITLE
v1.3.0

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -91,7 +91,7 @@ The *unpack* option determines if Arrow data should be "unpacked" from binary fo
 
 * *arrowTable*: An [Apache Arrow](https://arrow.apache.org/docs/js/) data table.
 * *options*: An Arrow import options object:
-  * *columns*: Ordered list of column names to include.
+  * *columns*: An ordered set of columns to import. The input may consist of: column name strings, column integer indices, objects with current column names as keys and new column names as values (for renaming), or a selection helper function such as [all](#all), [not](#not), or [range](#range)).
   * *unpack*: A boolean flag (default `false`) to unpack binary-encoded Arrow data to standard JavaScript values. Unpacking can incur an upfront time and memory cost to extract data to new arrays, but can speed up later query processing by enabling faster data access.
 
 *Examples*
@@ -99,6 +99,7 @@ The *unpack* option determines if Arrow data should be "unpacked" from binary fo
 ```js
 // requires that Apache Arrow has been imported as the 'arrow' variable
 // load an Arrow file from 'url' and create a corresponding Arquero table
+const arrow = require('apache-arrow');
 aq.fromArrow(await arrow.Table.from(fetch(url)))
 ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -83,12 +83,16 @@ aq.from(new Map([ ['d', 4], ['e', 5], ['f', 6] ])
 <hr/><a id="fromArrow" href="#fromArrow">#</a>
 <em>aq</em>.<b>fromArrow</b>(<i>arrowTable</i>[, <i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/from-arrow.js)
 
-Create a new <a href="table">table</a> backed by an [Apache Arrow](https://arrow.apache.org/) table instance.
+Create a new <a href="table">table</a> backed by an [Apache Arrow](https://arrow.apache.org/docs/js/) table instance. Both standard and filtered tables are supported. If the input Arrow table is filtered, new column arrays are created and filled with unpacked, non-filtered values.
 
- * *arrowTable*: An Apache Arrow data table.
- * *options*: An Arrow import options object:
-   * *columns*: Ordered list of column names to include.
-   * *unpack*: A boolean flag (default `false`) to unpack binary-encoded Arrow data to standard JavaScript values. Unpacking can incur an upfront time and memory cost to extract data to new arrays, but can speed up later query processing by enabling faster data access.
+For primitive data types, by default Arquero uses the binary-encoded Arrow columns as-is with zero data copying. Nested list or struct types are always unpacked into JavaScript array or object instances, respectively.
+
+The *unpack* option determines if Arrow data should be "unpacked" from binary format to standard JavaScript values. By default, Arrow columns for non-nested data types are used directly. This avoids data copies, but can result in slower access paths, particularly for dictionary columns and strings that need to be extracted from a backing buffer. With *unpack* set to `true`, Arquero performs extraction up front, increasing initialization time and memory use, but enabling faster performance for subsequent queries.
+
+* *arrowTable*: An [Apache Arrow](https://arrow.apache.org/docs/js/) data table.
+* *options*: An Arrow import options object:
+  * *columns*: Ordered list of column names to include.
+  * *unpack*: A boolean flag (default `false`) to unpack binary-encoded Arrow data to standard JavaScript values. Unpacking can incur an upfront time and memory cost to extract data to new arrays, but can speed up later query processing by enabling faster data access.
 
 *Examples*
 
@@ -104,12 +108,12 @@ aq.fromArrow(await arrow.Table.from(fetch(url)))
 
 Parse a comma-separated values (CSV) *text* string into a <a href="table">table</a>. Delimiters other than commas, such as tabs or pipes ('\|'), can be specified using the *options* argument. By default, automatic type inference is performed for input values; string values that match the ISO standard date format are parsed into JavaScript Date objects. To disable this behavior set *options.autoType* to `false`, which will cause all columns to be loaded as strings. To perform custom parsing of input column values, use *options.parse*.
 
- * *text*: A string in a delimited-value format.
- * *options*: A CSV format options object:
-   * *delimiter*: The delimiter string between column values.
-   * *header*: Boolean flag (default `true`) to specify the presence of a  header row. If `true`, indicates the CSV contains a header row with column names. If `false`, indicates the CSV does not contain a header row and the columns are given the names `'col1'`, `'col2'`, and so on.
-   * *autoType*: Boolean flag (default `true`) for automatic type inference.
-   * *parse*: Object of column parsing options. The object keys should be column names. The object values should be parsing functions to invoke to transform values upon input.
+* *text*: A string in a delimited-value format.
+* *options*: A CSV format options object:
+  * *delimiter*: The delimiter string between column values.
+  * *header*: Boolean flag (default `true`) to specify the presence of a  header row. If `true`, indicates the CSV contains a header row with column names. If `false`, indicates the CSV does not contain a header row and the columns are given the names `'col1'`, `'col2'`, and so on.
+  * *autoType*: Boolean flag (default `true`) for automatic type inference.
+  * *parse*: Object of column parsing options. The object keys should be column names. The object values should be parsing functions to invoke to transform values upon input.
 
 *Examples*
 

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -23,6 +23,7 @@ title: Operations \| Arquero API Reference
   * [row_number](#row_number), [rank](#rank), [avg_rank](#avg_rank), [dense_rank](#dense_rank)
   * [percent_rank](#percent_rank), [cume_dist](#cume_dist), [ntile](#ntile)
   * [lag](#lag), [lead](#lead), [first_value](#first_value), [last_value](#last_value), [nth_value](#nth_value)
+  * [fill_down](#fill_down), [fill_up](#fill_up)
 
 <br/>
 
@@ -1061,3 +1062,19 @@ Window function to assign the nth value in a sliding window frame (counting from
 
 * *field*: The data column or derived field.
 * *nth*: The nth position, starting from 1.
+
+<hr/><a id="fill_down" href="#fill_down">#</a>
+<em>op</em>.<b>fill_down</b>(<i>field</i>[, <i>defaultValue</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/index.js)
+
+Window function to fill in missing values with preceding values. Returns the value at the current window position if it is valid (not `null`, `undefined`, or `NaN`), otherwise returns the first preceding valid value. If no such value exists, returns the default value.
+
+* *field*: The data column or derived field.
+* *defaultValue*: The default value (default `undefined`).
+
+<hr/><a id="fill_up" href="#fill_up">#</a>
+<em>op</em>.<b>fill_up</b>(<i>field</i>[, <i>defaultValue</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/index.js)
+
+Window function to fill in missing values with subsequent values. Returns the value at the current window position if it is valid (not `null`, `undefined`, or `NaN`), otherwise returns the first subsequent valid value. If no such value exists, returns the default value.
+
+* *field*: The data column or derived field.
+* *defaultValue*: The default value (default `undefined`).

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -703,12 +703,12 @@ Determines whether a string *value* ends with the characters of a specified *sea
 * *length*: If provided, used as the length of *value* (default `value.length`).
 
 <hr/><a id="match" href="#match">#</a>
-<em>op</em>.<b>match</b>(<i>regexp</i>, <i>value</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/string.js)
+<em>op</em>.<b>match</b>(<i>value</i>, <i>regexp</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/string.js)
 
-Retrieves the result of matching a string *value* against a regular expression *regexp*. Returns `true` if the string is found, `false` otherwise.
+Retrieves the result of matching a string *value* against a regular expression *regexp*. Returns an array whose contents depend on the presence or absence of the regular expression global (`g`) flag, or `null` if no matches are found. If the `g` flag is used, all results matching the complete regular expression will be returned, but capturing groups will not. If the `g` flag is not used, only the first complete match and its related capturing groups are returned.
 
-* *regexp*: The regular expression to test with.
-* *value*: The input string to search for matches.
+* *value*: The input string value.
+* *regexp*: The [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) to match against.
 
 <hr/><a id="normalize" href="#normalize">#</a>
 <em>op</em>.<b>normalize</b>(<i>value</i>[, <i>form</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/string.js)

--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -35,7 +35,8 @@ title: Verbs \| Arquero API Reference
 Derive new column values based on the provided expressions.
 
 * *values*: Object of name-value pairs defining the columns to derive. The input object should have output column names for keys and table expressions for values.
-* *options*: An options object for relocating derived columns. Use either the *before* or *after* property to indicate where to place derived columns. Specifying both before and after is an error. Unlike the [relocate](#relocate) verb, this option affects only new columns; overwritten columns with existing names are excluded from relocation.
+* *options*: An options object for dropping or relocating derived columns. Use either the *before* or *after* property to indicate where to place derived columns. Specifying both before and after is an error. Unlike the [relocate](#relocate) verb, this option affects only new columns; overwritten columns with existing names are excluded from relocation.
+  * *drop*: A boolean (default `false`) indicating if the original columns should be dropped, leaving only the derived columns. If `true`, the *before* and *after* options are ignored.
   * *before*: An anchor column that relocated columns should be placed before. The value can be any legal column selection. If multiple columns are selected, only the *first* column will be used as an anchor.
   * *after*: An anchor column that relocated columns should be placed after. The value can be any legal column selection. If multiple columns are selected, only the *last* column will be used as an anchor.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arquero",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Query processing and transformation of array-backed data tables.",
   "keywords": [
     "data",
@@ -35,14 +35,14 @@
   },
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^11.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.1",
     "eslint": "^7.15.0",
     "esm": "^3.2.25",
     "rimraf": "^3.0.2",
-    "rollup": "^2.34.2",
+    "rollup": "^2.35.1",
     "rollup-plugin-bundle-size": "1.0.3",
     "rollup-plugin-terser": "^7.0.2",
     "tape": "^5.0.1",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.3"
   }
 }

--- a/src/engine/concat.js
+++ b/src/engine/concat.js
@@ -1,27 +1,21 @@
-import Column from '../table/column';
+import columnSet from '../table/column-set';
 
 export default function(table, others) {
   if (others.length === 0) return table;
 
   const tables = [table, ...others];
-  const names = table.columnNames();
   const nrows = tables.reduce((n, t) => n + t.numRows(), 0);
-  const data = {};
+  const cols = columnSet();
 
-  names.forEach(name => {
+  table.columnNames().forEach(name => {
     const arr = Array(nrows);
     let row = 0;
     tables.forEach(table => {
       const col = table.column(name) || { get: () => undefined };
       table.scan(trow => arr[row++] = col.get(trow));
     });
-    data[name] = Column.from(arr);
+    cols.add(name, arr);
   });
 
-  return table.create({
-    data,
-    filter: null,
-    groups: null,
-    order:  null
-  });
+  return table.create(cols.new());
 }

--- a/src/engine/fold.js
+++ b/src/engine/fold.js
@@ -1,19 +1,18 @@
 import unroll from './unroll';
 import { aggregateGet } from './reduce/util';
 
-export default function(table, { values = {}, ops = [] }, options = {}) {
-  const keys = Object.keys(values);
-  const n = keys.length;
-  if (n === 0) return table;
+export default function(table, { names = [], exprs = [], ops = [] }, options = {}) {
+  if (names.length === 0) return table;
 
-  const as = options.as || [];
-  const vals = aggregateGet(table, ops, Object.values(values));
-  const exprs = {
-    values: {
-      [as[0] || 'key']: () => keys,
-      [as[1] || 'value']: (row, data) => vals.map(fn => fn(row, data))
-    }
-  };
+  const [k = 'key', v = 'value'] = options.as || [];
+  const vals = aggregateGet(table, ops, exprs);
 
-  return unroll(table, exprs, { ...options, drop: values });
+  return unroll(
+    table,
+    {
+      names: [k, v],
+      exprs: [() => names, (row, data) => vals.map(fn => fn(row, data))]
+    },
+    { ...options, drop: names }
+  );
 }

--- a/src/engine/groupby.js
+++ b/src/engine/groupby.js
@@ -7,12 +7,11 @@ export default function(table, exprs) {
   });
 }
 
-function createGroups(table, { values = {}, ops = [] }) {
+function createGroups(table, { names = [], exprs = [], ops = [] }) {
   const data = table.data();
-  const names = Object.keys(values);
   if (names.length === 0) return null;
 
-  let get = aggregateGet(table, ops, Object.values(values));
+  let get = aggregateGet(table, ops, exprs);
   const getKey = keyFunction(get);
   const keys = new Uint32Array(table.totalRows());
   const index = {};

--- a/src/engine/lookup.js
+++ b/src/engine/lookup.js
@@ -1,11 +1,11 @@
 import { aggregateGet } from './reduce/util';
+import columnSet from '../table/column-set';
 
-export default function(tableL, tableR, [keyL, keyR], { values, ops }) {
+export default function(tableL, tableR, [keyL, keyR], { names, exprs, ops }) {
   // instantiate output data
-  const data = { ...tableL.columns() };
-  const names = Object.keys(values);
+  const cols = columnSet(tableL);
   const total = tableL.totalRows();
-  names.forEach(name => data[name] = Array(total));
+  names.forEach(name => cols.add(name, Array(total)));
 
   // build lookup table
   const lut = new Map();
@@ -29,11 +29,11 @@ export default function(tableL, tableR, [keyL, keyR], { values, ops }) {
 
   // output values for matching rows
   const dataR = tableR.data();
-  const get = aggregateGet(tableR, ops, Object.values(values));
+  const get = aggregateGet(tableR, ops, exprs);
   const n = get.length;
 
   for (let i = 0; i < n; ++i) {
-    const column = data[names[i]];
+    const column = cols.data[names[i]];
     const getter = get[i];
     for (let j = 0; j < m; ++j) {
       const rrow = rowR[j];
@@ -41,5 +41,5 @@ export default function(tableL, tableR, [keyL, keyR], { values, ops }) {
     }
   }
 
-  return tableL.create({ data });
+  return tableL.create(cols);
 }

--- a/src/engine/reduce.js
+++ b/src/engine/reduce.js
@@ -1,34 +1,31 @@
 import { groupInit, groupOutput, reduceFlat, reduceGroups } from './reduce/util';
+import columnSet from '../table/column-set';
 
 export default function(table, reducer) {
-  const data = {};
+  const cols = columnSet();
 
   if (table.isGrouped()) {
     const groups = table.groups();
-    const counts = groupInit(data, table);
+    const counts = groupInit(cols, table);
     output(
       reduceGroups(table, reducer, groups),
-      reducer, data, counts
+      reducer, cols, counts
     );
-    groupOutput(data, table, counts);
+    groupOutput(cols.data, table, counts);
   } else {
     output(
       reduceFlat(table, reducer),
-      reducer, data
+      reducer, cols
     );
   }
 
-  return table.create({
-    data,
-    filter: null,
-    groups: null,
-    order: null
-  });
+  return table.create(cols.new());
 }
 
-function output(cells, reducer, data, counts) {
+function output(cells, reducer, cols, counts) {
   // initialize output columns
-  reducer.outputs().map(name => data[name] = []);
+  reducer.outputs().map(name => cols.add(name, []));
+  const { data } = cols;
 
   // write aggregate values to output columns
   if (counts) {

--- a/src/engine/reduce/util.js
+++ b/src/engine/reduce/util.js
@@ -92,11 +92,11 @@ export function reduceGroups(table, reducer, groups) {
   return cells;
 }
 
-export function groupInit(data, table) {
+export function groupInit(cols, table) {
   const { names, size } = table.groups();
 
   // initialize group output columns
-  names.forEach(name => data[name] = Array(size));
+  names.forEach(name => cols.add(name, Array(size)));
 
   // return empty row count array
   return new Uint32Array(size + 1);

--- a/src/engine/select.js
+++ b/src/engine/select.js
@@ -1,16 +1,17 @@
+import columnSet from '../table/column-set';
 import error from '../util/error';
 import isString from '../util/is-string';
 
 export default function(table, columns) {
-  const data = {};
+  const cols = columnSet();
 
-  for (const curr in columns) {
-    const value = columns[curr];
+  columns.forEach((value, curr) => {
     const next = isString(value) ? value : curr;
     if (next) {
-      data[next] = table.column(curr) || error(`Unrecognized column: ${curr}`);
+      const col = table.column(curr) || error(`Unrecognized column: ${curr}`);
+      cols.add(next, col);
     }
-  }
+  });
 
-  return table.create({ data });
+  return table.create(cols);
 }

--- a/src/engine/spread.js
+++ b/src/engine/spread.js
@@ -1,24 +1,24 @@
 import { aggregateGet } from './reduce/util';
+import columnSet from '../table/column-set';
 import toArray from '../util/to-array';
 
-export default function(table, { values = {}, ops = [] }, options = {}) {
+export default function(table, { names, exprs, ops = [] }, options = {}) {
   const limit = options.limit > 0 ? +options.limit : Infinity;
-  const names = Object.keys(values);
   if (names.length === 0) return table;
 
   const as = (names.length === 1 && options.as) || [];
-  const get = aggregateGet(table, ops, Object.values(values));
-  const data = { ...table.data() };
+  const get = aggregateGet(table, ops, exprs);
+  const cols = columnSet(table);
 
   names.forEach((name, index) => {
     const columns = spread(table, get[index], limit);
     const n = columns.length;
     for (let i = 0; i < n; ++i) {
-      data[as[i] || `${name}${i + 1}`] = columns[i];
+      cols.add(as[i] || `${name}${i + 1}`, columns[i]);
     }
   });
 
-  return table.create({ data });
+  return table.create(cols);
 }
 
 function spread(table, get, limit) {

--- a/src/format/from-arrow.js
+++ b/src/format/from-arrow.js
@@ -2,6 +2,7 @@ import ColumnTable from '../table/column-table';
 import error from '../util/error';
 import toString from '../util/to-string';
 import unroll from '../util/unroll';
+import unroll2 from '../util/unroll2';
 
 // Hardwire Arrow type ids to avoid explicit dependency
 // https://github.com/apache/arrow/blob/master/js/src/enum.ts
@@ -25,89 +26,155 @@ export const STRUCT = 13;
  * @param {ColumnTable} table A new table containing the imported values.
  */
 export default function(arrowTable, options = {}) {
-  const columns = {};
-
   const names = options.columns || arrowTable.schema.fields.map(f => f.name);
-  const unpack = !!options.unpack;
+  const count = arrowTable.count();
 
-  names.forEach(name => {
-    const column = arrowTable.getColumn(name);
-    if (column == null) {
-      error(`Arrow column does not exist: ${toString(name)}`);
-    }
-    columns[name] = column.numChildren ? arrayFromNested(column)
-      : unpack ? arrayFromVector(column)
-      : column;
-  });
+  const cols = names.map(name =>
+    arrowTable.getColumn(name) ||
+    error(`Arrow column does not exist: ${toString(name)}`)
+  );
 
-  return new ColumnTable(columns);
+  const data = arrowTable.length === count
+    ? collect(names, cols, !!options.unpack)
+    : collectFiltered(arrowTable, names, cols, count);
+
+  return new ColumnTable(data, null, null, null, null, names);
 }
 
-function arrayFromNested(vector) {
+function collect(names, cols, unpack) {
+  const data = {};
+
+  cols.forEach((col, idx) =>
+    data[names[idx]] = col.numChildren ? arrayFromNested(col)
+      : unpack ? arrayFromVector(col)
+      : col
+  );
+
+  return data;
+}
+
+function collectFiltered(input, names, cols, count) {
+  const data = {};
+  const out = cols.map((col, idx) => data[names[idx]] = newArray(col, count));
+  const lut = cols.map(col => col.dictionary ? dictionaryLookup(col) : null);
+
+  let row = -1;
+  let batch = -1;
+  let collect;
+
+  input.scan(
+    idx => collect(++row, idx),
+    () => {
+      ++batch;
+      collect = unroll2(
+        out,
+        cols.map((col, i) => extractFrom(col.chunks[batch], lut[i])),
+        ['row', 'idx'],
+        '{' + out.map((_, i) => `_${i}[row]=$${i}(idx)`).join(';') + ';}'
+      );
+    }
+  );
+
+  return data;
+}
+
+// Typed Arrays can be used for the following Arrow types:
+//  Int = 2; Float = 3; Decimal = 7; Time = 9; Timestamp = 10;
+function newArray(col, count) {
+  if (!col.nullCount) {
+    const { ArrayType, typeId: id } = col;
+    if (id === 2 || id === 3 || id === 7 || id === 9 || id === 10) {
+      return new ArrayType(count);
+    }
+  }
+
+  return Array(count);
+}
+
+// extraction function for input vector
+// If dictionary type, lookup function must be provided
+function extractFrom(vector, lookup) {
+  return vector.numChildren ? extractFromNested(vector)
+    : vector.dictionary ? extractFromDictionary(vector, lookup)
+    : idx => vector.get(idx);
+}
+
+// extraction function for nested column types
+function extractFromNested(vector) {
   const extract = vector.typeId === LIST ? i => arrayExtractor(vector.get(i))
     : vector.typeId === STRUCT ? structExtractor(vector)
     : error(`Unsupported Arrow type: ${toString(vector.VectorName)}`);
-
-  // generate and return objects for each nested value
-  return Array.from(
-    { length: vector.length },
-    (_, i) => vector.isValid(i) ? extract(i) : null
-  );
+  return idx => vector.isValid(idx) ? extract(idx) : null;
 }
 
+// extraction function for dictionary-encoded values
+// For null bitmaps:
+//  j >> 3 advances the byte every 8 bits;
+//  (1 << (j & 7) checks if the relevant bit is set in that byte
+function extractFromDictionary(vector, lookup) {
+  const { nullBitmap: nulls, data: { values: keys } } = vector;
+  return nulls && nulls.length
+    ? i => (nulls[i >> 3] & (1 << (i & 7))) ? lookup(keys[i]) : null
+    : i => lookup(keys[i]);
+}
+
+// decode utf-8 only once per dictionary key
+// use the last chunk in case the dictionary builds as it goes
+// perform lazy extraction to avoid processing unused entries
+function dictionaryLookup(chunked) {
+  const chunk = chunked.chunks[chunked.chunks.length - 1];
+  const dict = chunk.dictionary;
+  const values = [];
+  return key => {
+    const v = values[key];
+    return v === undefined ? (values[key] = dict.get(key)) : v;
+  };
+}
+
+// extract from an array-typed vector, recurse if nested.
 function arrayExtractor(vector) {
-  // extract an array, recurse if nested.
   return vector.numChildren
     ? arrayFromNested(vector)
     : arrayFromVector(vector);
 }
 
+// extract struct field names and values
+// return function to generate objects with field name properties
 function structExtractor(vector) {
-  // extract struct field names and values
   const names = vector.type.children.map(field => field.name);
   const values = names.map((_, i) => arrayExtractor(vector.getChildAt(i)));
-
-  // function to generate objects with field name properties
   return unroll(
     values, 'i',
     '({' + names.map((_, d) => `${toString(_)}:_${d}[i]`) + '})'
   );
 }
 
-function arrayFromVector(column) {
-  // if dictionary column, perform more efficient extraction
-  // if has null values, extract to standard array
-  // otherwise, let Arrow try to use copy-less subarray call
-  return column.dictionary ? arrayFromDictionary(column)
-    : column.nullCount > 0 ? [...column]
-    : column.toArray();
+// generate and return objects for each nested value
+function arrayFromNested(vector) {
+  const extract = extractFromNested(vector);
+  return Array.from({ length: vector.length }, (_, i) => extract(i));
 }
 
-function arrayFromDictionary(column) {
-  // decode utf-8 only once per dictionary key
-  // use the last chunk in case the dictionary builds as it goes
-  const chunks = column.chunks;
-  const dict = chunks[chunks.length - 1].dictionary.toArray();
-  const array = new Array(column.length);
+// if dictionary column, perform more efficient extraction
+// if has null values, extract to standard array
+// otherwise, let Arrow try to use copy-less subarray call
+function arrayFromVector(vector) {
+  return vector.dictionary ? arrayFromDictionary(vector)
+    : vector.nullCount > 0 ? [...vector]
+    : vector.toArray();
+}
 
-  // populate array values
-  let i = -1;
-  for (const chunk of chunks) {
-    const { nullBitmap: nulls, data: { values, length: m } } = chunk;
-    if (nulls && nulls.length) {
-      for (let j = 0; j < m; ++j) {
-        // j >> 3 advances the byte every 8 bits;
-        // (1 << (j & 7) checks if the relevant bit is set in that byte
-        array[++i] = !(nulls[j >> 3] & (1 << (j & 7)))
-          ? null
-          : dict[values[j]];
-      }
-    } else {
-      for (let j = 0; j < m; ++j) {
-        array[++i] = dict[values[j]];
-      }
+// produce array of decoded dictionary values
+function arrayFromDictionary(vector) {
+  const lookup = dictionaryLookup(vector);
+  const array = Array(vector.length);
+  let row = -1;
+  for (const chunk of vector.chunks) {
+    const extract = extractFromDictionary(chunk, lookup);
+    const len = chunk.length;
+    for (let idx = 0; idx < len; ++idx) {
+      array[++row] = extract(idx);
     }
   }
-
   return array;
 }

--- a/src/format/from-arrow.js
+++ b/src/format/from-arrow.js
@@ -10,7 +10,7 @@ export const STRUCT = 13;
 
 /**
  * Options for Apache Arrow import.
- * @typedef {Object} ArrowOptions
+ * @typedef {object} ArrowOptions
  * @property {string[]} [columns] Ordered list of column names to import.
  * @property {boolean} [unpack=false] Flag to unpack binary-encoded Arrow
  *  data to standard JavaScript values. Unpacking can incur an upfront time
@@ -20,7 +20,7 @@ export const STRUCT = 13;
 
 /**
  * Create a new table backed by an Apache Arrow table instance.
- * @param {Object} arrowTable An Apache Arrow data table.
+ * @param {object} arrowTable An Apache Arrow data table.
  * @param {ArrowOptions} options Options for Arrow import.
  * @param {ColumnTable} table A new table containing the imported values.
  */

--- a/src/format/from-csv.js
+++ b/src/format/from-csv.js
@@ -8,14 +8,14 @@ const DEFAULT_COLUMN_NAME = 'col';
 
 /**
  * Options for CSV parsing.
- * @typedef {Object} CSVParseOptions
+ * @typedef {object} CSVParseOptions
  * @property {string} [delimiter=','] The delimiter between values.
  * @property {boolean} [autoType=true] Flag controlling automatic type inference.
  * @property {boolean} [header=true] Flag to specify presence of header row.
  *  If true, assumes the CSV contains a header row with column names.
  *  If false, indicates the CSV does not contain a header row, and the
  *  columns are given the names 'col1', 'col2', and so on.
- * @property {Object} [parse] Object of column parsing options.
+ * @property {object} [parse] Object of column parsing options.
  *  The object keys should be column names. The object values should be
  *  parsing functions to invoke to transform values upon input.
  */

--- a/src/format/from-json.js
+++ b/src/format/from-json.js
@@ -9,10 +9,10 @@ function autoType(key, value) {
 
 /**
  * Options for JSON parsing.
- * @typedef {Object} JSONParseOptions
+ * @typedef {object} JSONParseOptions
  * @property {boolean} [autoType=true] Flag controlling automatic type inference.
  *  If set to false, automatic date parsing for input JSON strings is disabled.
- * @property {Object} [parse] Object of column parsing options.
+ * @property {object} [parse] Object of column parsing options.
  *  The object keys should be column names. The object values should be
  *  parsing functions to invoke to transform values upon input.
  */
@@ -24,7 +24,7 @@ function autoType(key, value) {
  * date format are parsed into JavaScript Date objects. To disable this
  * behavior, set the autoType option to false. To perform custom parsing
  * of input column values, use the parse option.
- * @param {string|Object} data A string in a JSON format, or a
+ * @param {string|object} data A string in a JSON format, or a
  *  corresponding Object instance.
  * @param {JSONParseOptions} options The formatting options.
  * @param {ColumnTable} table A new table containing the parsed values.

--- a/src/format/to-csv.js
+++ b/src/format/to-csv.js
@@ -4,14 +4,14 @@ import isDate from '../util/is-date';
 
 /**
  * Options for CSV formatting.
- * @typedef {Object} CSVFormatOptions
+ * @typedef {object} CSVFormatOptions
  * @property {string} [delimiter=','] The delimiter between values.
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]|Function} [columns] Ordered list of column names
  *  to include. If function-valued, the function should accept a table as
  *  input and return an array of column name strings.
- * @property {Object} [format] Object of column format options.
+ * @property {object} [format] Object of column format options.
  *  The object keys should be column names. The object values should be
  *  formatting functions to invoke to transform column values prior to output.
  *  If specified, these override any automatically inferred options.

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -5,15 +5,15 @@ import mapObject from '../util/map-object';
 
 /**
  * Options for HTML formatting.
- * @typedef {Object} HTMLOptions
+ * @typedef {object} HTMLOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
- * @property {Object} [align] Object of column alignment options.
+ * @property {object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
  *  aligment strings, one of 'l' (left), 'c' (center), or 'r' (right).
  *  If specified, these override the automatically inferred options.
- * @property {Object} [format] Object of column format options.
+ * @property {object} [format] Object of column format options.
  *  The object keys should be column names. The object values should be
  *  formatting functions or objects with any of the following properties.
  *  If specified, these override the automatically inferred options.
@@ -23,7 +23,7 @@ import mapObject from '../util/map-object';
  *  If specified, this function will be invoked with the null or undefined
  *  value as the sole input, and the return value will be used as the HTML
  *  output for the value.
- * @property {Object} [style] CSS styles to include in HTML output.
+ * @property {object} [style] CSS styles to include in HTML output.
  *  The object keys should be HTML table tag names: 'table', 'thead',
  *  'tbody', 'tr', 'th', or 'td'. The object values should be strings of
  *  valid CSS style directives (such as "font-weight: bold;") or functions

--- a/src/format/to-json.js
+++ b/src/format/to-json.js
@@ -4,13 +4,13 @@ import isDate from '../util/is-date';
 
 /**
  * Options for JSON formatting.
- * @typedef {Object} JSONFormatOptions
+ * @typedef {object} JSONFormatOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]|Function} [columns] Ordered list of column names
  *  to include. If function-valued, the function should accept a table as
  *  input and return an array of column name strings.
- * @property {Object} [format] Object of column format options. The object
+ * @property {object} [format] Object of column format options. The object
  *  keys should be column names. The object values should be formatting
  *  functions to invoke to transform column values prior to output. If
  *  specified, these override any automatically inferred options.

--- a/src/format/to-markdown.js
+++ b/src/format/to-markdown.js
@@ -3,15 +3,15 @@ import { columns, formats, scan } from './util';
 
 /**
  * Options for Markdown formatting.
- * @typedef {Object} MarkdownOptions
+ * @typedef {object} MarkdownOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
- * @property {Object} [align] Object of column alignment options.
+ * @property {object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
  *  aligment strings, one of 'l' (left), 'c' (center), or 'r' (right).
  *  If specified, these override the automatically inferred options.
- * @property {Object} [format] Object of column format options.
+ * @property {object} [format] Object of column format options.
  *  The object keys should be column names. The object values should be
  *  formatting functions or objects with any of the following properties.
  *  If specified, these override the automatically inferred options.

--- a/src/op/aggregate-functions.js
+++ b/src/op/aggregate-functions.js
@@ -21,14 +21,14 @@ function initProduct(s, value) {
 /**
  * Initialize an aggregate operator.
  * @callback AggregateInit
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @return {void}
  */
 
 /**
  * Add a value to an aggregate operator.
  * @callback AggregateAdd
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @param {*} value The value to add.
  * @return {void}
  */
@@ -36,7 +36,7 @@ function initProduct(s, value) {
 /**
  * Remove a value from an aggregate operator.
  * @callback AggregateRem
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @param {*} value The value to remove.
  * @return {void}
  */
@@ -44,13 +44,13 @@ function initProduct(s, value) {
 /**
  * Retrive an output value from an aggregate operator.
  * @callback AggregateValue
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @return {*} The output value.
  */
 
 /**
  * An operator instance for an aggregate function.
- * @typedef {Object} AggregateOperator
+ * @typedef {object} AggregateOperator
  * @property {AggregateInit} init Initialize the operator.
  * @property {AggregateAdd} add Add a value to the operator state.
  * @property {AggregateRem} rem Remove a value from the operator state.
@@ -66,7 +66,7 @@ function initProduct(s, value) {
 
 /**
  * An operator definition for an aggregate function.
- * @typedef {Object} AggregateDef
+ * @typedef {object} AggregateDef
  * @property {AggregateCreate} create Create a new operator instance.
  * @property {number[]} param Two-element array containing the
  *  counts of input fields and additional parameters.

--- a/src/op/functions/string.js
+++ b/src/op/functions/string.js
@@ -3,7 +3,7 @@ export default {
   parse_float: (str) => Number.parseFloat(str),
   parse_int:   (str, radix) => Number.parseInt(str, radix),
   endswith:    (str, search, length) => String(str).endsWith(search, length),
-  match:       (regexp, str) => regexp.test(str),
+  match:       (str, regexp) => String(str).match(regexp),
   normalize:   (str, form) => String(str).normalize(form),
   padend:      (str, len, fill) => String(str).padEnd(len, fill),
   padstart:    (str, len, fill) => String(str).padStart(len, fill),

--- a/src/op/op-api.js
+++ b/src/op/op-api.js
@@ -289,5 +289,23 @@ export default {
    * @param {number} nth The nth position, starting from 1.
    * @return {*} The nth value in the current frame.
    */
-  nth_value: (field, nth) => Op('nth_value', field, nth)
+  nth_value: (field, nth) => Op('nth_value', field, nth),
+
+  /**
+   * Window function to fill in missing values with preceding values.
+   * @param {*} field The data field.
+   * @param {*} [defaultValue=undefined] The default value.
+   * @return {*} The current value if valid, otherwise the first preceding
+   *  valid value. If no such value exists, returns the default value.
+   */
+  fill_down: (field, defaultValue) => Op('fill_down', field, defaultValue),
+
+  /**
+   * Window function to fill in missing values with subsequent values.
+   * @param {*} field The data field.
+   * @param {*} [defaultValue=undefined] The default value.
+   * @return {*} The current value if valid, otherwise the first subsequent
+   *  valid value. If no such value exists, returns the default value.
+   */
+  fill_up: (field, defaultValue) => Op('fill_up', field, defaultValue)
 };

--- a/src/op/register.js
+++ b/src/op/register.js
@@ -28,7 +28,7 @@ function addOp(name, def, object, options = {}) {
 
 /**
  * Options for registering new functions formatting.
- * @typedef {Object} AddFunctionOptions
+ * @typedef {object} AddFunctionOptions
  * @property {boolean} [override=false] Flag indicating if the added
  *  function can override an existing function with the same name.
  * @param {number} [numFields=0] The number of field inputs to the operator.

--- a/src/op/window-functions.js
+++ b/src/op/window-functions.js
@@ -1,4 +1,5 @@
 import error from '../util/error';
+import isValid from '../util/is-valid';
 import noop from '../util/no-op';
 
 /**
@@ -216,5 +217,41 @@ export default {
       };
     },
     param: [1, 1]
+  },
+
+  /** @type {WindowDef} */
+  fill_down: {
+    create(defaultValue) {
+      let value;
+      return {
+        init: () => value = defaultValue,
+        value: (w, f) => {
+          const v = w.value(w.index, f);
+          return isValid(v) ? (value = v) : value;
+        }
+      };
+    },
+    param: [1, 1]
+  },
+
+  /** @type {WindowDef} */
+  fill_up: {
+    create(defaultValue) {
+      let value, idx;
+      return {
+        init: () => (value = defaultValue, idx = -1),
+        value: (w, f) => w.index <= idx ? value
+          : (idx = find(w, f, w.index)) >= 0 ? (value = w.value(idx, f))
+          : (idx = w.size, value = defaultValue)
+      };
+    },
+    param: [1, 1]
   }
 };
+
+function find(w, f, i) {
+  for (const n = w.size; i < n; ++i) {
+    if (isValid(w.value(i, f))) return i;
+  }
+  return -1;
+}

--- a/src/op/window-functions.js
+++ b/src/op/window-functions.js
@@ -16,7 +16,7 @@ import noop from '../util/no-op';
 
 /**
  * An operator instance for a window function.
- * @typedef {Object} WindowOperator
+ * @typedef {object} WindowOperator
  * @property {AggregateInit} init Initialize the operator.
  * @property {AggregateValue} value Retrieve an output value.
  */
@@ -30,7 +30,7 @@ import noop from '../util/no-op';
 
 /**
  * An operator definition for a window function.
- * @typedef {Object} WindowDef
+ * @typedef {object} WindowDef
  * @property {AggregateCreate} create Create a new operator instance.
  * @property {number[]} param Two-element array containing the
  *  counts of input fields and additional parameters.

--- a/src/query/query-builder.js
+++ b/src/query/query-builder.js
@@ -90,7 +90,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for count transformations.
-   * @typedef {Object} CountOptions
+   * @typedef {object} CountOptions
    * @property {string} [as='count'] The name of the output count column.
    */
 
@@ -125,16 +125,16 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} DeriveOptions
+   * @typedef {object} DeriveOptions
    * @property {boolean} [drop=false] A flag indicating if the original
    *  columns should be dropped, leaving only the derived columns. If true,
    *  the before and after options are ignored.
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -143,7 +143,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Derive new column values based on the provided expressions.
-   * @param {Object} values Object of name-value pairs defining the
+   * @param {object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
    * @param {DeriveOptions=} options Options for dropping or relocating
@@ -221,13 +221,13 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} RelocateOptions
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @typedef {object} RelocateOptions
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -237,7 +237,7 @@ export default class QueryBuilder extends Query {
   /**
    * Relocate a subset of columns to change their positions, also
    * potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns An
+   * @param {string|string[]|number|number[]|object|Function} columns An
    * ordered selection of columns to relocate. The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -262,7 +262,7 @@ export default class QueryBuilder extends Query {
    * Rollup a table to produce an aggregate summary.
    * Often used in conjunction with {@link QueryBuilder#groupby}.
    * To produce counts only, {@link QueryBuilder#count} is a convenient shortcut.
-   * @param {Object} values Object of name-value pairs defining aggregated
+   * @param {object} values Object of name-value pairs defining aggregated
    *  output columns. The input object should have output column
    *  names for keys and table expressions for values.
    * @return {QueryBuilder} A new builder with "rollup" verb appended.
@@ -275,7 +275,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for sample transformations.
-   * @typedef {Object} SampleOptions
+   * @typedef {object} SampleOptions
    * @property {boolean} [replace=false] Flag for sampling with replacement.
    * @property {Function|string} [weight] Column values to use as weights
    *  for sampling. Rows will be sampled with probability proportional to
@@ -303,7 +303,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Select a subset of columns into a new table, potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns The columns to select.
+   * @param {string|string[]|number|number[]|object|Function} columns The columns to select.
    *  The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -345,7 +345,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for fold transformations.
-   * @typedef {Object} FoldOptions
+   * @typedef {object} FoldOptions
    * @property {string[]} [as=['key', 'value']] An array indicating the
    *  output column names to use for the key and value columns, respectively.
    */
@@ -373,7 +373,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for pivot transformations.
-   * @typedef {Object} PivotOptions
+   * @typedef {object} PivotOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string} [keySeparator='_'] A string to place between multiple key names.
    * @property {string} [valueSeparator='_'] A string to place between key and value names.
@@ -393,7 +393,7 @@ export default class QueryBuilder extends Query {
    * @param {*} keys Key values to map to new column names. Keys may be an
    *  array of column name strings, column index numbers, or value objects
    *  with output column names for keys and table expressions for values.
-   * @param {string|string[]|Object} values Output values for pivoted columns.
+   * @param {string|string[]|object} values Output values for pivoted columns.
    *  Column string names will be wrapped in any *any* aggregate.
    *  If object-valued, the input object should have output value
    *  names for keys and table expressions for values.
@@ -409,7 +409,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for spread transformations.
-   * @typedef {Object} SpreadOptions
+   * @typedef {object} SpreadOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string[]} [as] Output column names to use. This option only
    *  applies when a single column is spread. If the given array of names is
@@ -420,7 +420,7 @@ export default class QueryBuilder extends Query {
   /**
    * Spread array elements into a set of new columns.
    * Output columns are named based on the value key and array index.
-   * @param {string|Array|Object} values The columns to spread, as either
+   * @param {string|Array|object} values The columns to spread, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {SpreadOptions=} [options] Options for spreading.
    * @return {QueryBuilder} A new builder with "spread" verb appended.
@@ -433,14 +433,14 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for unroll transformations.
-   * @typedef {Object} UnrollOptions
+   * @typedef {object} UnrollOptions
    * @property {number} [limit=Infinity] The maximum number of new rows
    *  to generate per array value.
    * @property {boolean|string} [index=false] Flag or column name for adding
    *  zero-based array index values as an output column. If true, a new column
    *  named "index" will be included. If string-valued, a new column with
    *  the given name will be added.
-   * @property {string|string[]|number|number[]|Object|Function} [drop]
+   * @property {string|string[]|number|number[]|object|Function} [drop]
    *  A selection of columns to drop (exclude) from the unrolled output.
    *  The input may consist of:
    *  - column name strings,
@@ -456,7 +456,7 @@ export default class QueryBuilder extends Query {
    * If more than one array value is used, the number of new rows
    * is the smaller of the limit and the largest length.
    * Values for all other columns are copied over.
-   * @param {string|Array|Object} values The columns to unroll, as either
+   * @param {string|Array|object} values The columns to unroll, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {UnrollOptions} [options] Options for unrolling.
    * @return {QueryBuilder} A new builder with "unroll" verb appended.
@@ -479,7 +479,7 @@ export default class QueryBuilder extends Query {
    * @param {Array} on A two-element array of lookup keys (column name
    *  strings or table expressions) for this table and the secondary table,
    *  respectively.
-   * @param {string|Object} values The column values to add from the
+   * @param {string|object} values The column values to add from the
    *  secondary table. Can be column name strings or objects with column
    *  names as keys and table expressions as values.
    * @return {QueryBuilder} A new builder with "lookup" verb appended.
@@ -491,7 +491,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for join transformations.
-   * @typedef {Object} JoinOptions
+   * @typedef {object} JoinOptions
    * @property {boolean} [left=false] Flag indicating a left outer join.
    *  If both the *left* and *right* are true, indicates a full outer join.
    * @property {boolean} [right=false] Flag indicating a right outer join.
@@ -522,7 +522,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -558,7 +558,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -596,7 +596,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -634,7 +634,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -663,7 +663,7 @@ export default class QueryBuilder extends Query {
    * This is a convenience method for {@link QueryBuilder#join} in which the
    * join criteria is always true.
    * @param {string} other The name of the other (right) table to join with.
-   * @param {Array|Object} [values] The columns to include in the output.
+   * @param {Array|object} [values] The columns to include in the output.
    *  If unspecified, all columns from both tables are included.
    *  If array-valued, a two element array should be provided, containing
    *  the columns to include for the left and right tables, respectively.

--- a/src/query/query-builder.js
+++ b/src/query/query-builder.js
@@ -124,15 +124,33 @@ export default class QueryBuilder extends Query {
   }
 
   /**
+   * Options for relocate transformations.
+   * @typedef {Object} DeriveOptions
+   * @property {boolean} [drop=false] A flag indicating if the original
+   *  columns should be dropped, leaving only the derived columns. If true,
+   *  the before and after options are ignored.
+   * @property {string|string[]|number|number[]|Object|Function} [before]
+   *  An anchor column that relocated columns should be placed before.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the first column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   * @property {string|string[]|number|number[]|Object|Function} [after]
+   *  An anchor column that relocated columns should be placed after.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the last column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   */
+
+  /**
    * Derive new column values based on the provided expressions.
    * @param {Object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
-   * @param {RelocateOptions=} options Options for relocating derived columns.
-   *  Use either a before or after property to indicate where to place
-   *  derived columns. Specifying both before and after is an error. Unlike
-   *  the relocate verb, this option affects only new columns; updated
-   *  columns with existing names are excluded from relocation.
+   * @param {DeriveOptions=} options Options for dropping or relocating
+   *  derived columns. Use either a before or after property to indicate
+   *  where to place derived columns. Specifying both before and after is an
+   *  error. Unlike the relocate verb, this option affects only new columns;
+   *  updated columns with existing names are excluded from relocation.
    * @return {QueryBuilder} A new builder with "derive" verb appended.
    * @example query.derive({ sumXY: d => d.x + d.y })
    * @example query.derive({ z: d => d.x * d.y }, { before: 'x' })

--- a/src/query/query.js
+++ b/src/query/query.js
@@ -50,8 +50,8 @@ export default class Query {
    * as an object. Otherwise, adds the provided parameters to this
    * query's parameter set and returns the table. Any prior parameters
    * with names matching the input parameters are overridden.
-   * @param {Object} values The parameter values.
-   * @return {Query|Object} The current parameter values (if called
+   * @param {object} values The parameter values.
+   * @return {Query|object} The current parameter values (if called
    *  with no arguments) or this query.
    */
   params(values) {

--- a/src/query/to-ast.js
+++ b/src/query/to-ast.js
@@ -59,7 +59,7 @@ function astOptions(value, types = {}) {
 }
 
 function astParse(expr, opt) {
-  return parse({ expr }, { ...opt, ast: true }).expr;
+  return parse({ expr }, { ...opt, ast: true }).exprs[0];
 }
 
 function astColumn(name) {

--- a/src/table/column-set.js
+++ b/src/table/column-set.js
@@ -1,0 +1,30 @@
+import has from '../util/has';
+
+export default function(table) {
+  return table
+    ? new ColumnSet({ ...table.data() }, table.columnNames())
+    : new ColumnSet();
+}
+
+class ColumnSet {
+  constructor(data, names) {
+    this.data = data || {};
+    this.names = names || [];
+  }
+
+  add(name, values) {
+    if (!this.has(name)) this.names.push(name + '');
+    return this.data[name] = values;
+  }
+
+  has(name) {
+    return has(this.data, name);
+  }
+
+  new() {
+    this.filter = null;
+    this.groups = null;
+    this.order = null;
+    return this;
+  }
+}

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -57,7 +57,7 @@ export default class ColumnTable extends Table {
 
   /**
    * Get the backing set of columns for this table.
-   * @return {Object} Object of named column instances.
+   * @return {object} Object of named column instances.
    */
   columns() {
     return this._data;

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -33,14 +33,14 @@ export default class ColumnTable extends Table {
     return new ColumnTable(columnsFrom(values, names));
   }
 
-  constructor(columns, filter, group, order, params) {
+  constructor(columns, filter, group, order, params, names) {
     mapObject(columns, Column.from, columns);
-    const names = Object.keys(columns);
+    names = names || Object.keys(columns);
     const nrows = names.length ? columns[names[0]].length : 0;
     super(names, nrows, columns, filter, group, order, params);
   }
 
-  create({ data, filter, groups, order }) {
+  create({ data, names, filter, groups, order }) {
     const f = filter
       ? (this._filter ? this._filter.and(filter) : filter)
       : filter !== undefined ? filter : this._filter;
@@ -50,7 +50,8 @@ export default class ColumnTable extends Table {
       f,
       groups !== undefined ? groups : regroup(this._group, filter && f),
       order !== undefined ? order : this._order,
-      this._params
+      this._params,
+      names || (!data ? this._names : null)
     );
   }
 

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -49,13 +49,14 @@ export default class Table {
    * setting is not specified, it is inherited from the current table.
    * @param {Object} [config] Configuration settings for the new table:
    *  - data: The data payload to use.
+   *  - names: An ordered list of column names.
    *  - filter: An additional filter bitset to apply.
    *  - groups: The groupby specification to use (null for no groups).
    *  - order: The orderby comparator to use (null for no order).
    *  - params: Table expression parameters.
    * @return {Table} A newly created table.
    */
-  create({ data, filter, groups, order }) { // eslint-disable-line no-unused-vars
+  create({ data, names, filter, groups, order }) { // eslint-disable-line no-unused-vars
   }
 
   /**
@@ -439,17 +440,35 @@ export default class Table {
   }
 
   /**
+   * Options for relocate transformations.
+   * @typedef {Object} DeriveOptions
+   * @property {boolean} [drop=false] A flag indicating if the original
+   *  columns should be dropped, leaving only the derived columns. If true,
+   *  the before and after options are ignored.
+   * @property {string|string[]|number|number[]|Object|Function} [before]
+   *  An anchor column that relocated columns should be placed before.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the first column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   * @property {string|string[]|number|number[]|Object|Function} [after]
+   *  An anchor column that relocated columns should be placed after.
+   *  The value can be any legal column selection. If multiple columns are
+   *  selected, only the last column will be used as an anchor.
+   *  It is an error to specify both before and after options.
+   */
+
+  /**
    * Derive new column values based on the provided expressions. By default,
    * new columns are added after (higher indices than) existing columns. Use
    * the before or after options to place new columns elsewhere.
    * @param {Object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
-   * @param {RelocateOptions=} options Options for relocating derived columns.
-   *  Use either a before or after property to indicate where to place
-   *  derived columns. Specifying both before and after is an error. Unlike
-   *  the relocate verb, this option affects only new columns; updated
-   *  columns with existing names are excluded from relocation.
+   * @param {DeriveOptions=} options Options for dropping or relocating
+   *  derived columns. Use either a before or after property to indicate
+   *  where to place derived columns. Specifying both before and after is an
+   *  error. Unlike the relocate verb, this option affects only new columns;
+   *  updated columns with existing names are excluded from relocation.
    * @return {Table} A new table with derived columns added.
    * @example table.derive({ sumXY: d => d.x + d.y })
    * @example table.derive({ z: d => d.x * d.y }, { before: 'x' })

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -12,11 +12,11 @@ export default class Table {
    * @param {number} nrows - The number of rows.
    * @param {*} data - The backing data, which can vary by implementation.
    * @param {BitSet} [filter] - A bit mask for which rows to include.
-   * @param {Object} [groups] - Row grouping criteria.
+   * @param {object} [groups] - Row grouping criteria.
    * @param {string[]} [groups.names] - Output column names for grouping variables.
    * @param {function[]} [groups.get] - Accessor functions for grouping variables.
    * @param {function} [order] - A comparator function for sorting rows.
-   * @param {Object} [params] - Parameter values for table expressions.
+   * @param {object} [params] - Parameter values for table expressions.
    */
   constructor(names, nrows, data, filter, groups, order, params) {
     this._names = Object.freeze(names);
@@ -47,7 +47,7 @@ export default class Table {
    * The new table may have different data, filter, grouping, or ordering
    * based on the values of the optional configuration argument. If a
    * setting is not specified, it is inherited from the current table.
-   * @param {Object} [config] Configuration settings for the new table:
+   * @param {object} [config] Configuration settings for the new table:
    *  - data: The data payload to use.
    *  - names: An ordered list of column names.
    *  - filter: An additional filter bitset to apply.
@@ -104,7 +104,7 @@ export default class Table {
 
   /**
    * A table groupby specification.
-   * @typedef {Object} GroupBySpec
+   * @typedef {object} GroupBySpec
    * @property {number} size - The number of groups.
    * @property {string[]} names - Column names for each group.
    * @property {Function[]} get - Value accessor functions for each group.
@@ -216,7 +216,7 @@ export default class Table {
 
   /**
    * Options for generating row objects.
-   * @typedef {Object} ObjectsOptions
+   * @typedef {object} ObjectsOptions
    * @property {number} [limit=Infinity] The maximum number of objects to create.
    * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
    */
@@ -336,7 +336,7 @@ export default class Table {
    * Callback function invoked for each row of a table scan.
    * @callback scanVisitor
    * @param {number} row The table row index.
-   * @param {Object|Array} data The backing table data store.
+   * @param {object|Array} data The backing table data store.
    * @param {Function} stop Function to stop the scan early.
    *  Callees can invoke this function to prevent future calls.
    */
@@ -386,8 +386,8 @@ export default class Table {
    * as an object. Otherwise, adds the provided parameters to this
    * table's parameter set and returns the table. Any prior parameters
    * with names matching the input parameters are overridden.
-   * @param {Object} values The parameter values.
-   * @return {Table|Object} The current parameters values (if called with
+   * @param {object} values The parameter values.
+   * @return {Table|object} The current parameters values (if called with
    *  no arguments) or this table.
    */
   params(values) {
@@ -405,7 +405,7 @@ export default class Table {
 
   /**
    * Options for count transformations.
-   * @typedef {Object} CountOptions
+   * @typedef {object} CountOptions
    * @property {string} [as='count'] The name of the output count column.
    */
 
@@ -441,16 +441,16 @@ export default class Table {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} DeriveOptions
+   * @typedef {object} DeriveOptions
    * @property {boolean} [drop=false] A flag indicating if the original
    *  columns should be dropped, leaving only the derived columns. If true,
    *  the before and after options are ignored.
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -461,7 +461,7 @@ export default class Table {
    * Derive new column values based on the provided expressions. By default,
    * new columns are added after (higher indices than) existing columns. Use
    * the before or after options to place new columns elsewhere.
-   * @param {Object} values Object of name-value pairs defining the
+   * @param {object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
    * @param {DeriveOptions=} options Options for dropping or relocating
@@ -551,13 +551,13 @@ export default class Table {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} RelocateOptions
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @typedef {object} RelocateOptions
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -567,7 +567,7 @@ export default class Table {
   /**
    * Relocate a subset of columns to change their positions, also
    * potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns An
+   * @param {string|string[]|number|number[]|object|Function} columns An
    * ordered selection of columns to relocate. The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -592,7 +592,7 @@ export default class Table {
    * Rollup a table to produce an aggregate summary.
    * Often used in conjunction with {@link Table#groupby}.
    * To produce counts only, {@link Table#count} is a convenient shortcut.
-   * @param {Object} values Object of name-value pairs defining aggregated
+   * @param {object} values Object of name-value pairs defining aggregated
    *  output columns. The input object should have output column
    *  names for keys and table expressions for values.
    * @return {Table} A new table of aggregate summary values.
@@ -605,7 +605,7 @@ export default class Table {
 
   /**
    * Options for sample transformations.
-   * @typedef {Object} SampleOptions
+   * @typedef {object} SampleOptions
    * @property {boolean} [replace=false] Flag for sampling with replacement.
    * @property {Function|string} [weight] Column values to use as weights
    *  for sampling. Rows will be sampled with probability proportional to
@@ -633,7 +633,7 @@ export default class Table {
 
   /**
    * Select a subset of columns into a new table, potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns The columns to select.
+   * @param {string|string[]|number|number[]|object|Function} columns The columns to select.
    *  The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -675,7 +675,7 @@ export default class Table {
 
   /**
    * Options for fold transformations.
-   * @typedef {Object} FoldOptions
+   * @typedef {object} FoldOptions
    * @property {string[]} [as=['key', 'value']] An array indicating the
    *  output column names to use for the key and value columns, respectively.
    */
@@ -703,7 +703,7 @@ export default class Table {
 
   /**
    * Options for pivot transformations.
-   * @typedef {Object} PivotOptions
+   * @typedef {object} PivotOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string} [keySeparator='_'] A string to place between multiple key names.
    * @property {string} [valueSeparator='_'] A string to place between key and value names.
@@ -723,7 +723,7 @@ export default class Table {
    * @param {*} keys Key values to map to new column names. Keys may be an
    *  array of column name strings, column index numbers, or value objects
    *  with output column names for keys and table expressions for values.
-   * @param {string|string[]|Object} values Output values for pivoted columns.
+   * @param {string|string[]|object} values Output values for pivoted columns.
    *  Column string names will be wrapped in any *any* aggregate.
    *  If object-valued, the input object should have output value
    *  names for keys and table expressions for values.
@@ -739,7 +739,7 @@ export default class Table {
 
   /**
    * Options for spread transformations.
-   * @typedef {Object} SpreadOptions
+   * @typedef {object} SpreadOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string[]} [as] Output column names to use. This option only
    *  applies when a single column is spread. If the given array of names is
@@ -750,7 +750,7 @@ export default class Table {
   /**
    * Spread array elements into a set of new columns.
    * Output columns are named based on the value key and array index.
-   * @param {string|Array|Object} values The columns to spread, as either
+   * @param {string|Array|object} values The columns to spread, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {SpreadOptions=} [options] Options for spreading.
    * @return {Table} A new table with the spread columns added.
@@ -763,14 +763,14 @@ export default class Table {
 
   /**
    * Options for unroll transformations.
-   * @typedef {Object} UnrollOptions
+   * @typedef {object} UnrollOptions
    * @property {number} [limit=Infinity] The maximum number of new rows
    *  to generate per array value.
    * @property {boolean|string} [index=false] Flag or column name for adding
    *  zero-based array index values as an output column. If true, a new column
    *  named "index" will be included. If string-valued, a new column with
    *  the given name will be added.
-   * @property {string|string[]|number|number[]|Object|Function} [drop]
+   * @property {string|string[]|number|number[]|object|Function} [drop]
    *  A selection of columns to drop (exclude) from the unrolled output.
    *  The input may consist of:
    *  - column name strings,
@@ -786,7 +786,7 @@ export default class Table {
    * If more than one array value is used, the number of new rows
    * is the smaller of the limit and the largest length.
    * Values for all other columns are copied over.
-   * @param {string|Array|Object} values The columns to unroll, as either
+   * @param {string|Array|object} values The columns to unroll, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {UnrollOptions=} [options] Options for unrolling.
    * @return {Table} A new unrolled table.
@@ -809,7 +809,7 @@ export default class Table {
    * @param {Array} on A two-element array of lookup keys (column name
    *  strings or table expressions) for this table and the secondary table,
    *  respectively.
-   * @param {string|Object} values The column values to add from the
+   * @param {string|object} values The column values to add from the
    *  secondary table. Can be column name strings or objects with column
    *  names as keys and table expressions as values.
    * @return {Table} A new table with lookup values added.
@@ -821,7 +821,7 @@ export default class Table {
 
   /**
    * Options for join transformations.
-   * @typedef {Object} JoinOptions
+   * @typedef {object} JoinOptions
    * @property {boolean} [left=false] Flag indicating a left outer join.
    *  If both the *left* and *right* are true, indicates a full outer join.
    * @property {boolean} [right=false] Flag indicating a right outer join.
@@ -852,7 +852,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -888,7 +888,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -926,7 +926,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -964,7 +964,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -993,7 +993,7 @@ export default class Table {
    * This is a convenience method for {@link Table#join} in which the
    * join criteria is always true.
    * @param {Table} other The other (right) table to join with.
-   * @param {Array|Object} [values] The columns to include in the output.
+   * @param {Array|object} [values] The columns to include in the output.
    *  If unspecified, all columns from both tables are included.
    *  If array-valued, a two element array should be provided, containing
    *  the columns to include for the left and right tables, respectively.

--- a/src/util/assign.js
+++ b/src/util/assign.js
@@ -1,0 +1,8 @@
+import entries from './entries';
+
+export default function(map, pairs) {
+  for (const [key, value] of entries(pairs)) {
+    map.set(key, value);
+  }
+  return map;
+}

--- a/src/util/entries.js
+++ b/src/util/entries.js
@@ -1,0 +1,8 @@
+import isArray from './is-array';
+import isMap from './is-map';
+
+export default function(value) {
+  return isArray(value) ? value
+    : isMap(value) ? value.entries()
+    : Object.entries(value);
+}

--- a/src/util/is-function.js
+++ b/src/util/is-function.js
@@ -1,3 +1,3 @@
-export default function isFunction(value) {
+export default function(value) {
   return typeof value === 'function';
 }

--- a/src/util/is-map.js
+++ b/src/util/is-map.js
@@ -1,3 +1,3 @@
 export default function(value) {
-  return value === Object(value);
+  return value instanceof Map;
 }

--- a/src/util/is-string.js
+++ b/src/util/is-string.js
@@ -1,3 +1,3 @@
-export default function isString(value) {
+export default function(value) {
   return typeof value === 'string';
 }

--- a/src/util/is-valid.js
+++ b/src/util/is-valid.js
@@ -1,3 +1,3 @@
-export default function isValid(value) {
+export default function(value) {
   return value != null && value === value;
 }

--- a/src/verbs/derive.js
+++ b/src/verbs/derive.js
@@ -3,12 +3,12 @@ import _derive from '../engine/derive';
 import parse from '../expression/parse';
 
 export default function(table, values, options = {}) {
-  const dt = _derive(table, parse(values, { table }));
+  const dt = _derive(table, parse(values, { table }), options);
 
-  return options.before == null && options.after == null
+  return options.drop || (options.before == null && options.after == null)
     ? dt
     : relocate(dt,
-        Object.keys(values).filter(name => table.columnIndex(name) < 0),
+        Object.keys(values).filter(name => !table.column(name)),
         options
       );
 }

--- a/src/verbs/expr/bin.js
+++ b/src/verbs/expr/bin.js
@@ -1,6 +1,6 @@
 /**
  * Options for binning number values.
- * @typedef {Object} BinOptions
+ * @typedef {object} BinOptions
  * @property {number} [maxbins] The maximum number of bins.
  * @property {number} [minstep] The minimum step size between bins.
  * @property {boolean} [nice=true] Flag indicating if bins should

--- a/src/verbs/expr/desc.js
+++ b/src/verbs/expr/desc.js
@@ -2,8 +2,8 @@ import wrap from './wrap';
 
 /**
  * Annotate a table expression to indicate descending sort order.
- * @param {string|Function|Object} expr The table expression to annotate.
- * @return {Object} A wrapped expression indicating descending sort.
+ * @param {string|Function|object} expr The table expression to annotate.
+ * @return {object} A wrapped expression indicating descending sort.
  * @example desc('colA')
  * @example desc(d => d.colA)
  */

--- a/src/verbs/expr/field.js
+++ b/src/verbs/expr/field.js
@@ -2,7 +2,7 @@ import wrap from './wrap';
 
 /**
  * Annotate an expression to indicate it is a string field reference.
- * @param {string|Object} expr The column name, or an existing wrapped
+ * @param {string|object} expr The column name, or an existing wrapped
  *  expression for a column name.
  * @param {string} [name] The column name to use. If provided, will
  *  overwrite the input expression value.

--- a/src/verbs/expr/parse-key.js
+++ b/src/verbs/expr/parse-key.js
@@ -9,15 +9,15 @@ import keyFunction from '../../util/key-function';
 import toArray from '../../util/to-array';
 
 export default function(name, table, params) {
-  const exprs = {};
+  const exprs = new Map();
 
   toArray(params).forEach((param, i) => {
     param = isNumber(param) ? table.columnName(param) : param;
-    isString(param) ? (exprs[i] = field(param))
-      : isFunction(param) || isObject(param) && param.expr ? (exprs[i] = param)
+    isString(param) ? exprs.set(i, field(param))
+      : isFunction(param) || isObject(param) && param.expr ? exprs.set(i, param)
       : error(`Invalid ${name} key value: ${param+''}`);
   });
 
   const fn = parse(exprs, { table, aggregate: false, window: false });
-  return keyFunction(Object.values(fn.values), true);
+  return keyFunction(fn.exprs, true);
 }

--- a/src/verbs/expr/parse.js
+++ b/src/verbs/expr/parse.js
@@ -1,6 +1,7 @@
 import field from './field';
 import resolve from './selection';
 import parse from '../../expression/parse';
+import assign from '../../util/assign';
 import error from '../../util/error';
 import isNumber from '../../util/is-number';
 import isObject from '../../util/is-object';
@@ -9,13 +10,13 @@ import isFunction from '../../util/is-function';
 import toArray from '../../util/to-array';
 
 export default function(name, table, params, options = { window: false }) {
-  const exprs = {};
+  const exprs = new Map();
 
   const marshal = param => {
     param = isNumber(param) ? table.columnName(param) : param;
-    isString(param) ? (exprs[param] = field(param))
-      : isFunction(param) ? Object.keys(resolve(table, param)).forEach(marshal)
-      : isObject(param) ? Object.assign(exprs, param)
+    isString(param) ? exprs.set(param, field(param))
+      : isFunction(param) ? resolve(table, param).forEach(marshal)
+      : isObject(param) ? assign(exprs, param)
       : error(`Invalid ${name} value: ${param+''}`);
   };
 

--- a/src/verbs/expr/rolling.js
+++ b/src/verbs/expr/rolling.js
@@ -5,7 +5,7 @@ import wrap from './wrap';
  * functions within a sliding window frame. For example, to specify a
  * rolling 7-day average centered on the current day, use rolling with
  * a frame value of [-3, 3].
- * @param {string|Function|Object} expr The table expression to annotate.
+ * @param {string|Function|object} expr The table expression to annotate.
  * @param {[number?, number?]} [frame=[-Infinity, 0]] The sliding window frame
  *  offsets. Each entry indicates an offset from the current value. If an
  *  entry is non-finite, the frame will be unbounded in that direction,

--- a/src/verbs/expr/selection.js
+++ b/src/verbs/expr/selection.js
@@ -1,3 +1,4 @@
+import assign from '../../util/assign';
 import error from '../../util/error';
 import escapeRegExp from '../../util/escape-regexp';
 import isArray from '../../util/is-array';
@@ -7,17 +8,17 @@ import isNumber from '../../util/is-number';
 import isString from '../../util/is-string';
 import toString from '../../util/to-string';
 
-export default function resolve(table, sel, map = {}) {
+export default function resolve(table, sel, map = new Map()) {
   sel = isNumber(sel) ? table.columnName(sel) : sel;
 
   if (isString(sel)) {
-    map[sel] = sel;
+    map.set(sel, sel);
   } else if (isArray(sel)) {
     sel.forEach(r => resolve(table, r, map));
   } else if (isFunction(sel)) {
     resolve(table, sel(table), map);
   } else if (isObject(sel)) {
-    Object.assign(map, sel);
+    assign(map, sel);
   } else {
     error(`Invalid column selection: ${toString(sel)}`);
   }
@@ -60,7 +61,7 @@ export function not(...selection) {
   return decorate(
     table => {
       const drop = resolve(table, selection);
-      return table.columnNames(name => !drop[name]);
+      return table.columnNames(name => !drop.has(name));
     },
     () => ({ not: toObject(selection) })
   );

--- a/src/verbs/expr/selection.js
+++ b/src/verbs/expr/selection.js
@@ -93,7 +93,7 @@ export function range(start, end) {
 export function matches(pattern) {
   if (isString(pattern)) pattern = RegExp(escapeRegExp(pattern));
   return decorate(
-    table => table.columnNames().filter(name => pattern.test(name)),
+    table => table.columnNames(name => pattern.test(name)),
     () => ({ matches: [pattern.source, pattern.flags] })
   );
 }

--- a/src/verbs/expr/wrap.js
+++ b/src/verbs/expr/wrap.js
@@ -2,9 +2,9 @@ import isFunction from '../../util/is-function';
 
 /**
  * Annotate an expression in an object wrapper.
- * @param {string|Function|Object} expr An expression to annotate.
- * @param {Object} properties The properties to annotate with.
- * @return {Object} A new wrapped expression object.
+ * @param {string|Function|object} expr An expression to annotate.
+ * @param {object} properties The properties to annotate with.
+ * @return {object} A new wrapped expression object.
  */
 export default function(expr, properties) {
   return expr && expr.expr

--- a/src/verbs/filter.js
+++ b/src/verbs/filter.js
@@ -3,11 +3,11 @@ import _filter from '../engine/filter';
 import parse from '../expression/parse';
 
 export default function(table, criteria) {
-  const expr = parse({ test: criteria }, { table });
-  let { test } = expr.values;
-  if (expr.ops.length) {
-    const bv = _derive(table, expr).column('test');
-    test = row => bv.get(row);
+  const test = parse({ test: criteria }, { table });
+  let predicate = test.exprs[0];
+  if (test.ops.length) {
+    const bv = _derive(table, test, { drop: true }).column('test');
+    predicate = row => bv.get(row);
   }
-  return _filter(table, test);
+  return _filter(table, predicate);
 }

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -71,8 +71,11 @@ export {
  * @return {ColumnTable} the instantiated table
  * @example table({ colA: ['a', 'b', 'c'], colB: [3, 4, 5] })
  */
-export function table(columns) {
-  return new ColumnTable(mapObject(columns, x => x));
+export function table(columns, names) {
+  return new ColumnTable(
+    mapObject(columns, x => x),
+    null, null, null, null, names
+  );
 }
 
 /**

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -63,7 +63,7 @@ export {
 
 /**
  * Create a new table for a set of named columns.
- * @param {Object.<string, Array|TypedArray>} columns
+ * @param {object} columns
  *  The set of named column arrays.
  *  Object keys are the column names.
  *  The enumeration order of the keys determines the column indices.
@@ -81,7 +81,7 @@ export function table(columns, names) {
 /**
  * Create a new table from an existing object, such as an array of
  * objects or a set of key-value pairs.
- * @param {Object|Array|Map} values Data values to populate the table.
+ * @param {object|Array|Map} values Data values to populate the table.
  *  If array-valued or iterable, imports rows for each non-null value,
  *  using the provided column names as keys for each row object. If no
  *  names are provided, the first non-null object's own keys are used.

--- a/src/verbs/join-filter.js
+++ b/src/verbs/join-filter.js
@@ -11,7 +11,7 @@ export default function(tableL, tableR, on, options) {
         parseKey('join', tableL, on[0]),
         parseKey('join', tableR, on[1])
       )
-    : parse({ on }, { join: [tableL, tableR] }).values.on;
+    : parse({ on }, { join: [tableL, tableR] }).exprs[0];
 
   return _join_filter(tableL, tableR, on, options);
 }

--- a/src/verbs/orderby.js
+++ b/src/verbs/orderby.js
@@ -12,22 +12,22 @@ export default function(table, values) {
 }
 
 function parseValues(table, params) {
-  const exprs = {};
-
   let index = -1;
+  const exprs = new Map();
+  const add = val => exprs.set(++index + '', val);
+
   params.forEach(param => {
     const expr = param.expr != null ? param.expr : param;
 
     if (isObject(expr) && !isFunction(expr)) {
-      for (const key in expr) {
-        exprs[++index] = expr[key];
-      }
+      for (const key in expr) add(expr[key]);
     } else {
-      param = isNumber(expr) ? field(param, table.columnName(expr))
-        : isString(expr) ? field(param)
-        : isFunction(expr) ? param
-        : error(`Invalid orderby field: ${param+''}`);
-      exprs[++index] = param;
+      add(
+        isNumber(expr) ? field(param, table.columnName(expr))
+          : isString(expr) ? field(param)
+          : isFunction(expr) ? param
+          : error(`Invalid orderby field: ${param+''}`)
+      );
     }
   });
 

--- a/src/verbs/pivot.js
+++ b/src/verbs/pivot.js
@@ -11,12 +11,10 @@ export default function(table, on, values, options) {
   );
 }
 
-function preparse(values) {
+function preparse(map) {
   // map direct field reference to "any" aggregate
-  for (const key in values) {
-    const value = values[key];
-    if (value.field) {
-      values[key] = `d => any(d[${JSON.stringify(value+'')}])`;
-    }
-  }
+  map.forEach((value, key) => value.field
+    ? map.set(key, `d => any(d[${JSON.stringify(value+'')}])`)
+    : 0
+  );
 }

--- a/src/verbs/relocate.js
+++ b/src/verbs/relocate.js
@@ -1,7 +1,6 @@
 import _select from '../engine/select';
 import resolve from './expr/selection';
 import error from '../util/error';
-import has from '../util/has';
 
 export default function(table, columns, { before, after } = {}) {
   const bef = before != null;
@@ -15,24 +14,26 @@ export default function(table, columns, { before, after } = {}) {
   }
 
   columns = resolve(table, columns);
-  const anchors = Object.keys(resolve(table, bef ? before : after));
+  const anchors = [...resolve(table, bef ? before : after).keys()];
   const anchor = bef ? anchors[0] : anchors.pop();
-  const _cols = {};
+  const select = new Map();
 
   // marshal inputs to select in desired order
   table.columnNames().forEach(name => {
     // check if we should assign the current column
-    const assign = !has(columns, name);
+    const assign = !columns.has(name);
 
     // at anchor column, insert relocated columns
     if (name === anchor) {
-      if (aft && assign) _cols[name] = name;
-      Object.assign(_cols, columns);
+      if (aft && assign) select.set(name, name);
+      for (const [key, value] of columns) {
+        select.set(key, value);
+      }
       if (aft) return; // exit if current column has been handled
     }
 
-    if (assign) _cols[name] = name;
+    if (assign) select.set(name, name);
   });
 
-  return _select(table, _cols);
+  return _select(table, select);
 }

--- a/src/verbs/unroll.js
+++ b/src/verbs/unroll.js
@@ -6,7 +6,7 @@ export default function(table, values, options) {
     table,
     parse('unroll', table, values),
     options && options.drop
-      ? { ...options, drop: parse('unroll', table, options.drop).values }
+      ? { ...options, drop: parse('unroll', table, options.drop).names }
       : options
   );
 }

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -292,3 +292,35 @@ tape('derive supports recode function', t => {
 
   t.end();
 });
+
+tape('derive supports fill window functions', t => {
+  const t1 = table({ x: ['a', null, undefined, 'b', NaN, null, 'c'] });
+
+  tableEqual(t,
+    t1.derive({ x: op.fill_down('x') }),
+    { x: ['a', 'a', 'a', 'b', 'b', 'b', 'c'] },
+    'derive data, fill_down'
+  );
+
+  tableEqual(t,
+    t1.derive({ x: op.fill_up('x') }),
+    { x: ['a', 'b', 'b', 'b', 'c', 'c', 'c'] },
+    'derive data, fill_up'
+  );
+
+  const t2 = table({ x: [null, 'a', null] });
+
+  tableEqual(t,
+    t2.derive({ x: op.fill_down('x', '?') }),
+    { x: ['?', 'a', 'a'] },
+    'derive data, fill_down with default'
+  );
+
+  tableEqual(t,
+    t2.derive({ x: op.fill_up('x', '?') }),
+    { x: ['a', 'a', '?'] },
+    'derive data, fill_up with default'
+  );
+
+  t.end();
+});

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -22,10 +22,25 @@ tape('derive overwrites existing columns', t => {
     b: [2, 4, 6, 8]
   };
 
-  const dt = table(data).derive({ a: d => d.a + d.b });
-  t.equal(dt.numRows(), 4, 'num rows');
-  t.equal(dt.numCols(), 2, 'num cols');
-  tableEqual(t, dt, { ...data, a: [3, 7, 11, 15] }, 'derive data');
+  tableEqual(t,
+    table(data).derive({ a: d => d.a + d.b }),
+    { ...data, a: [3, 7, 11, 15] },
+    'derive data'
+  );
+  t.end();
+});
+
+tape('derive drops existing columns with option', t => {
+  const data = {
+    a: [1, 3, 5, 7],
+    b: [2, 4, 6, 8]
+  };
+
+  tableEqual(t,
+    table(data).derive({ z: d => d.a + d.b }, { drop: true }),
+    { z: [3, 7, 11, 15] },
+    'derive data'
+  );
   t.end();
 });
 

--- a/test/verbs/pivot-test.js
+++ b/test/verbs/pivot-test.js
@@ -89,3 +89,22 @@ tape('pivot respects input options', t => {
 
   t.end();
 });
+
+tape('pivot correctly orders integer column names', t => {
+  const data = {
+    g: ['a', 'a', 'a', 'b', 'b', 'b'],
+    k: [2002, 2001, 2000, 2002, 2001, 2000],
+    x: [1, 2, 3, 4, 5, 6]
+  };
+
+  const ut = table(data)
+    .groupby('g')
+    .pivot('k', 'x', { sort: false });
+
+  tableEqual(t, ut, {
+    'g': ['a', 'b'], '2002': [ 1, 4 ], '2001': [ 2, 5 ], '2000': [ 3, 6 ]
+  }, 'pivot data');
+
+  t.deepEqual(ut.columnNames(), ['g', '2002', '2001', '2000']);
+  t.end();
+});

--- a/test/verbs/select-test.js
+++ b/test/verbs/select-test.js
@@ -19,6 +19,27 @@ tape('select selects a subset of columns', t => {
   t.end();
 });
 
+tape('select handles columns with numeric names', t => {
+  const data = {
+    country: [0],
+    '1999': [1],
+    '2000': [2]
+  };
+
+  const dt = table(data, ['country', '1999', '2000']);
+  t.deepEqual(
+    dt.columnNames(),
+    ['country', '1999', '2000']
+  );
+
+  t.deepEqual(
+    dt.select('1999', 'country', '2000').columnNames(),
+    ['1999', 'country', '2000']
+  );
+
+  t.end();
+});
+
 tape('select renames columns', t => {
   const data = {
     a: [1, 3, 5, 7],

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,10 +46,10 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
 
-"@rollup/plugin-node-resolve@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.0.tgz#770458fb26691a686c5f29f37dded94832ffce59"
-  integrity sha512-8Hrmwjn1pLYjUxcv7U7IPP0qfnzEJWHyHE6CaZ8jbLM+8axaarJRB1jB6JgKTDp5gNga+TpsgX6F8iuvgOerKQ==
+"@rollup/plugin-node-resolve@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.0.1.tgz#d3765eec4bccf960801439a999382aed2dca959b"
+  integrity sha512-ltlsj/4Bhwwhb+Nb5xCz/6vieuEj2/BAkkqVIKmZwC7pIdl8srmgmglE4S0jFlZa32K4qvdQ6NHdmpRKD/LwoQ==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -73,9 +73,9 @@
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/node@*":
-  version "14.14.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.11.tgz#fc25a4248a5e8d0837019b1d170146d07334abe0"
-  integrity sha512-BJ97wAUuU3NUiUCp44xzUFquQEvnk1wu7q4CMEUYKJWjdkr0YWYDsm4RFtAvxYsNjLsKcrFt6RvK8r+mnzMbEQ==
+  version "14.14.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.13.tgz#9e425079799322113ae8477297ae6ef51b8e0cdf"
+  integrity sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ==
 
 "@types/resolve@1.17.1":
   version "1.17.1"
@@ -728,12 +728,12 @@ is-arguments@^1.0.4:
   dependencies:
     call-bind "^1.0.0"
 
-is-bigint@^1.0.0:
+is-bigint@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.1.tgz#6923051dfcbc764278540b9ce0e6b3213aa5ebc2"
   integrity sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==
 
-is-boolean-object@^1.0.0:
+is-boolean-object@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.0.tgz#e2aaad3a3a8fca34c28f6eee135b156ed2587ff0"
   integrity sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==
@@ -775,9 +775,9 @@ is-glob@^4.0.0, is-glob@^4.0.1:
     is-extglob "^2.1.1"
 
 is-map@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
-  integrity sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
 is-module@^1.0.0:
   version "1.0.0"
@@ -789,7 +789,7 @@ is-negative-zero@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
   integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
 
-is-number-object@^1.0.3:
+is-number-object@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
   integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
@@ -802,16 +802,16 @@ is-regex@^1.0.5, is-regex@^1.1.1:
     has-symbols "^1.0.1"
 
 is-set@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.1.tgz#d1604afdab1724986d30091575f54945da7e5f43"
-  integrity sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
 
-is-string@^1.0.4, is-string@^1.0.5:
+is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
-is-symbol@^1.0.2:
+is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
   integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
@@ -1109,10 +1109,10 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.34.2:
-  version "2.34.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.34.2.tgz#fa73e05c64df587e9ed4dc80d7d4e7d4a43f8908"
-  integrity sha512-mvtQLqu3cNeoctS+kZ09iOPxrc1P1/Bt1z15enuQ5feyKOdM3MJAVFjjsygurDpSWn530xB4AlA83TWIzRstXA==
+rollup@^2.35.1:
+  version "2.35.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.35.1.tgz#e6bc8d10893556a638066f89e8c97f422d03968c"
+  integrity sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -1330,10 +1330,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 uri-js@^4.2.2:
   version "4.4.0"
@@ -1348,15 +1348,15 @@ v8-compile-cache@^2.0.3:
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
 
 which-boxed-primitive@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz#cbe8f838ebe91ba2471bb69e9edbda67ab5a5ec1"
-  integrity sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
   dependencies:
-    is-bigint "^1.0.0"
-    is-boolean-object "^1.0.0"
-    is-number-object "^1.0.3"
-    is-string "^1.0.4"
-    is-symbol "^1.0.2"
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-collection@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Changes from [v1.2.3](https://github.com/uwdata/arquero/releases/tag/v1.2.3):

- Add `fill_down` and `fill_up` window functions.
- Add boolean `drop` option to `derive()` verb to drop original columns and retain derived columns only.
- Add support for pre-filtered Apache Arrow tables.
- Add flexible column selection for Apache Arrow import.
- Add TypeScript types to build output, compiled from JSDoc comments. (thanks @dworthen!)
- Fix internal column name handling to properly order integer-named columns.
- Fix `op.match` to use the proper string match method.
- Fix JSDoc types to use `object`, not `Object`.