### PR TITLE
Fix JSDoc types to use object, not Object.

### DIFF
--- a/src/format/from-arrow.js
+++ b/src/format/from-arrow.js
@@ -10,7 +10,7 @@ export const STRUCT = 13;
 
 /**
  * Options for Apache Arrow import.
- * @typedef {Object} ArrowOptions
+ * @typedef {object} ArrowOptions
  * @property {string[]} [columns] Ordered list of column names to import.
  * @property {boolean} [unpack=false] Flag to unpack binary-encoded Arrow
  *  data to standard JavaScript values. Unpacking can incur an upfront time
@@ -20,7 +20,7 @@ export const STRUCT = 13;
 
 /**
  * Create a new table backed by an Apache Arrow table instance.
- * @param {Object} arrowTable An Apache Arrow data table.
+ * @param {object} arrowTable An Apache Arrow data table.
  * @param {ArrowOptions} options Options for Arrow import.
  * @param {ColumnTable} table A new table containing the imported values.
  */

--- a/src/format/from-csv.js
+++ b/src/format/from-csv.js
@@ -8,14 +8,14 @@ const DEFAULT_COLUMN_NAME = 'col';
 
 /**
  * Options for CSV parsing.
- * @typedef {Object} CSVParseOptions
+ * @typedef {object} CSVParseOptions
  * @property {string} [delimiter=','] The delimiter between values.
  * @property {boolean} [autoType=true] Flag controlling automatic type inference.
  * @property {boolean} [header=true] Flag to specify presence of header row.
  *  If true, assumes the CSV contains a header row with column names.
  *  If false, indicates the CSV does not contain a header row, and the
  *  columns are given the names 'col1', 'col2', and so on.
- * @property {Object} [parse] Object of column parsing options.
+ * @property {object} [parse] Object of column parsing options.
  *  The object keys should be column names. The object values should be
  *  parsing functions to invoke to transform values upon input.
  */

--- a/src/format/from-json.js
+++ b/src/format/from-json.js
@@ -9,10 +9,10 @@ function autoType(key, value) {
 
 /**
  * Options for JSON parsing.
- * @typedef {Object} JSONParseOptions
+ * @typedef {object} JSONParseOptions
  * @property {boolean} [autoType=true] Flag controlling automatic type inference.
  *  If set to false, automatic date parsing for input JSON strings is disabled.
- * @property {Object} [parse] Object of column parsing options.
+ * @property {object} [parse] Object of column parsing options.
  *  The object keys should be column names. The object values should be
  *  parsing functions to invoke to transform values upon input.
  */
@@ -24,7 +24,7 @@ function autoType(key, value) {
  * date format are parsed into JavaScript Date objects. To disable this
  * behavior, set the autoType option to false. To perform custom parsing
  * of input column values, use the parse option.
- * @param {string|Object} data A string in a JSON format, or a
+ * @param {string|object} data A string in a JSON format, or a
  *  corresponding Object instance.
  * @param {JSONParseOptions} options The formatting options.
  * @param {ColumnTable} table A new table containing the parsed values.

--- a/src/format/to-csv.js
+++ b/src/format/to-csv.js
@@ -4,14 +4,14 @@ import isDate from '../util/is-date';
 
 /**
  * Options for CSV formatting.
- * @typedef {Object} CSVFormatOptions
+ * @typedef {object} CSVFormatOptions
  * @property {string} [delimiter=','] The delimiter between values.
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]|Function} [columns] Ordered list of column names
  *  to include. If function-valued, the function should accept a table as
  *  input and return an array of column name strings.
- * @property {Object} [format] Object of column format options.
+ * @property {object} [format] Object of column format options.
  *  The object keys should be column names. The object values should be
  *  formatting functions to invoke to transform column values prior to output.
  *  If specified, these override any automatically inferred options.

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -5,15 +5,15 @@ import mapObject from '../util/map-object';
 
 /**
  * Options for HTML formatting.
- * @typedef {Object} HTMLOptions
+ * @typedef {object} HTMLOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
- * @property {Object} [align] Object of column alignment options.
+ * @property {object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
  *  aligment strings, one of 'l' (left), 'c' (center), or 'r' (right).
  *  If specified, these override the automatically inferred options.
- * @property {Object} [format] Object of column format options.
+ * @property {object} [format] Object of column format options.
  *  The object keys should be column names. The object values should be
  *  formatting functions or objects with any of the following properties.
  *  If specified, these override the automatically inferred options.
@@ -23,7 +23,7 @@ import mapObject from '../util/map-object';
  *  If specified, this function will be invoked with the null or undefined
  *  value as the sole input, and the return value will be used as the HTML
  *  output for the value.
- * @property {Object} [style] CSS styles to include in HTML output.
+ * @property {object} [style] CSS styles to include in HTML output.
  *  The object keys should be HTML table tag names: 'table', 'thead',
  *  'tbody', 'tr', 'th', or 'td'. The object values should be strings of
  *  valid CSS style directives (such as "font-weight: bold;") or functions

--- a/src/format/to-json.js
+++ b/src/format/to-json.js
@@ -4,13 +4,13 @@ import isDate from '../util/is-date';
 
 /**
  * Options for JSON formatting.
- * @typedef {Object} JSONFormatOptions
+ * @typedef {object} JSONFormatOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]|Function} [columns] Ordered list of column names
  *  to include. If function-valued, the function should accept a table as
  *  input and return an array of column name strings.
- * @property {Object} [format] Object of column format options. The object
+ * @property {object} [format] Object of column format options. The object
  *  keys should be column names. The object values should be formatting
  *  functions to invoke to transform column values prior to output. If
  *  specified, these override any automatically inferred options.

--- a/src/format/to-markdown.js
+++ b/src/format/to-markdown.js
@@ -3,15 +3,15 @@ import { columns, formats, scan } from './util';
 
 /**
  * Options for Markdown formatting.
- * @typedef {Object} MarkdownOptions
+ * @typedef {object} MarkdownOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
  * @property {string[]} [columns] Ordered list of column names to print.
- * @property {Object} [align] Object of column alignment options.
+ * @property {object} [align] Object of column alignment options.
  *  The object keys should be column names. The object values should be
  *  aligment strings, one of 'l' (left), 'c' (center), or 'r' (right).
  *  If specified, these override the automatically inferred options.
- * @property {Object} [format] Object of column format options.
+ * @property {object} [format] Object of column format options.
  *  The object keys should be column names. The object values should be
  *  formatting functions or objects with any of the following properties.
  *  If specified, these override the automatically inferred options.

--- a/src/op/aggregate-functions.js
+++ b/src/op/aggregate-functions.js
@@ -21,14 +21,14 @@ function initProduct(s, value) {
 /**
  * Initialize an aggregate operator.
  * @callback AggregateInit
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @return {void}
  */
 
 /**
  * Add a value to an aggregate operator.
  * @callback AggregateAdd
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @param {*} value The value to add.
  * @return {void}
  */
@@ -36,7 +36,7 @@ function initProduct(s, value) {
 /**
  * Remove a value from an aggregate operator.
  * @callback AggregateRem
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @param {*} value The value to remove.
  * @return {void}
  */
@@ -44,13 +44,13 @@ function initProduct(s, value) {
 /**
  * Retrive an output value from an aggregate operator.
  * @callback AggregateValue
- * @param {Object} state The aggregate state object.
+ * @param {object} state The aggregate state object.
  * @return {*} The output value.
  */
 
 /**
  * An operator instance for an aggregate function.
- * @typedef {Object} AggregateOperator
+ * @typedef {object} AggregateOperator
  * @property {AggregateInit} init Initialize the operator.
  * @property {AggregateAdd} add Add a value to the operator state.
  * @property {AggregateRem} rem Remove a value from the operator state.
@@ -66,7 +66,7 @@ function initProduct(s, value) {
 
 /**
  * An operator definition for an aggregate function.
- * @typedef {Object} AggregateDef
+ * @typedef {object} AggregateDef
  * @property {AggregateCreate} create Create a new operator instance.
  * @property {number[]} param Two-element array containing the
  *  counts of input fields and additional parameters.

--- a/src/op/register.js
+++ b/src/op/register.js
@@ -28,7 +28,7 @@ function addOp(name, def, object, options = {}) {
 
 /**
  * Options for registering new functions formatting.
- * @typedef {Object} AddFunctionOptions
+ * @typedef {object} AddFunctionOptions
  * @property {boolean} [override=false] Flag indicating if the added
  *  function can override an existing function with the same name.
  * @param {number} [numFields=0] The number of field inputs to the operator.

--- a/src/op/window-functions.js
+++ b/src/op/window-functions.js
@@ -16,7 +16,7 @@ import noop from '../util/no-op';
 
 /**
  * An operator instance for a window function.
- * @typedef {Object} WindowOperator
+ * @typedef {object} WindowOperator
  * @property {AggregateInit} init Initialize the operator.
  * @property {AggregateValue} value Retrieve an output value.
  */
@@ -30,7 +30,7 @@ import noop from '../util/no-op';
 
 /**
  * An operator definition for a window function.
- * @typedef {Object} WindowDef
+ * @typedef {object} WindowDef
  * @property {AggregateCreate} create Create a new operator instance.
  * @property {number[]} param Two-element array containing the
  *  counts of input fields and additional parameters.

--- a/src/query/query-builder.js
+++ b/src/query/query-builder.js
@@ -90,7 +90,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for count transformations.
-   * @typedef {Object} CountOptions
+   * @typedef {object} CountOptions
    * @property {string} [as='count'] The name of the output count column.
    */
 
@@ -125,16 +125,16 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} DeriveOptions
+   * @typedef {object} DeriveOptions
    * @property {boolean} [drop=false] A flag indicating if the original
    *  columns should be dropped, leaving only the derived columns. If true,
    *  the before and after options are ignored.
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -143,7 +143,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Derive new column values based on the provided expressions.
-   * @param {Object} values Object of name-value pairs defining the
+   * @param {object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
    * @param {DeriveOptions=} options Options for dropping or relocating
@@ -221,13 +221,13 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} RelocateOptions
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @typedef {object} RelocateOptions
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -237,7 +237,7 @@ export default class QueryBuilder extends Query {
   /**
    * Relocate a subset of columns to change their positions, also
    * potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns An
+   * @param {string|string[]|number|number[]|object|Function} columns An
    * ordered selection of columns to relocate. The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -262,7 +262,7 @@ export default class QueryBuilder extends Query {
    * Rollup a table to produce an aggregate summary.
    * Often used in conjunction with {@link QueryBuilder#groupby}.
    * To produce counts only, {@link QueryBuilder#count} is a convenient shortcut.
-   * @param {Object} values Object of name-value pairs defining aggregated
+   * @param {object} values Object of name-value pairs defining aggregated
    *  output columns. The input object should have output column
    *  names for keys and table expressions for values.
    * @return {QueryBuilder} A new builder with "rollup" verb appended.
@@ -275,7 +275,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for sample transformations.
-   * @typedef {Object} SampleOptions
+   * @typedef {object} SampleOptions
    * @property {boolean} [replace=false] Flag for sampling with replacement.
    * @property {Function|string} [weight] Column values to use as weights
    *  for sampling. Rows will be sampled with probability proportional to
@@ -303,7 +303,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Select a subset of columns into a new table, potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns The columns to select.
+   * @param {string|string[]|number|number[]|object|Function} columns The columns to select.
    *  The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -345,7 +345,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for fold transformations.
-   * @typedef {Object} FoldOptions
+   * @typedef {object} FoldOptions
    * @property {string[]} [as=['key', 'value']] An array indicating the
    *  output column names to use for the key and value columns, respectively.
    */
@@ -373,7 +373,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for pivot transformations.
-   * @typedef {Object} PivotOptions
+   * @typedef {object} PivotOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string} [keySeparator='_'] A string to place between multiple key names.
    * @property {string} [valueSeparator='_'] A string to place between key and value names.
@@ -393,7 +393,7 @@ export default class QueryBuilder extends Query {
    * @param {*} keys Key values to map to new column names. Keys may be an
    *  array of column name strings, column index numbers, or value objects
    *  with output column names for keys and table expressions for values.
-   * @param {string|string[]|Object} values Output values for pivoted columns.
+   * @param {string|string[]|object} values Output values for pivoted columns.
    *  Column string names will be wrapped in any *any* aggregate.
    *  If object-valued, the input object should have output value
    *  names for keys and table expressions for values.
@@ -409,7 +409,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for spread transformations.
-   * @typedef {Object} SpreadOptions
+   * @typedef {object} SpreadOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string[]} [as] Output column names to use. This option only
    *  applies when a single column is spread. If the given array of names is
@@ -420,7 +420,7 @@ export default class QueryBuilder extends Query {
   /**
    * Spread array elements into a set of new columns.
    * Output columns are named based on the value key and array index.
-   * @param {string|Array|Object} values The columns to spread, as either
+   * @param {string|Array|object} values The columns to spread, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {SpreadOptions=} [options] Options for spreading.
    * @return {QueryBuilder} A new builder with "spread" verb appended.
@@ -433,14 +433,14 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for unroll transformations.
-   * @typedef {Object} UnrollOptions
+   * @typedef {object} UnrollOptions
    * @property {number} [limit=Infinity] The maximum number of new rows
    *  to generate per array value.
    * @property {boolean|string} [index=false] Flag or column name for adding
    *  zero-based array index values as an output column. If true, a new column
    *  named "index" will be included. If string-valued, a new column with
    *  the given name will be added.
-   * @property {string|string[]|number|number[]|Object|Function} [drop]
+   * @property {string|string[]|number|number[]|object|Function} [drop]
    *  A selection of columns to drop (exclude) from the unrolled output.
    *  The input may consist of:
    *  - column name strings,
@@ -456,7 +456,7 @@ export default class QueryBuilder extends Query {
    * If more than one array value is used, the number of new rows
    * is the smaller of the limit and the largest length.
    * Values for all other columns are copied over.
-   * @param {string|Array|Object} values The columns to unroll, as either
+   * @param {string|Array|object} values The columns to unroll, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {UnrollOptions} [options] Options for unrolling.
    * @return {QueryBuilder} A new builder with "unroll" verb appended.
@@ -479,7 +479,7 @@ export default class QueryBuilder extends Query {
    * @param {Array} on A two-element array of lookup keys (column name
    *  strings or table expressions) for this table and the secondary table,
    *  respectively.
-   * @param {string|Object} values The column values to add from the
+   * @param {string|object} values The column values to add from the
    *  secondary table. Can be column name strings or objects with column
    *  names as keys and table expressions as values.
    * @return {QueryBuilder} A new builder with "lookup" verb appended.
@@ -491,7 +491,7 @@ export default class QueryBuilder extends Query {
 
   /**
    * Options for join transformations.
-   * @typedef {Object} JoinOptions
+   * @typedef {object} JoinOptions
    * @property {boolean} [left=false] Flag indicating a left outer join.
    *  If both the *left* and *right* are true, indicates a full outer join.
    * @property {boolean} [right=false] Flag indicating a right outer join.
@@ -522,7 +522,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -558,7 +558,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -596,7 +596,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -634,7 +634,7 @@ export default class QueryBuilder extends Query {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -663,7 +663,7 @@ export default class QueryBuilder extends Query {
    * This is a convenience method for {@link QueryBuilder#join} in which the
    * join criteria is always true.
    * @param {string} other The name of the other (right) table to join with.
-   * @param {Array|Object} [values] The columns to include in the output.
+   * @param {Array|object} [values] The columns to include in the output.
    *  If unspecified, all columns from both tables are included.
    *  If array-valued, a two element array should be provided, containing
    *  the columns to include for the left and right tables, respectively.

--- a/src/query/query.js
+++ b/src/query/query.js
@@ -50,8 +50,8 @@ export default class Query {
    * as an object. Otherwise, adds the provided parameters to this
    * query's parameter set and returns the table. Any prior parameters
    * with names matching the input parameters are overridden.
-   * @param {Object} values The parameter values.
-   * @return {Query|Object} The current parameter values (if called
+   * @param {object} values The parameter values.
+   * @return {Query|object} The current parameter values (if called
    *  with no arguments) or this query.
    */
   params(values) {

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -57,7 +57,7 @@ export default class ColumnTable extends Table {
 
   /**
    * Get the backing set of columns for this table.
-   * @return {Object} Object of named column instances.
+   * @return {object} Object of named column instances.
    */
   columns() {
     return this._data;

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -12,11 +12,11 @@ export default class Table {
    * @param {number} nrows - The number of rows.
    * @param {*} data - The backing data, which can vary by implementation.
    * @param {BitSet} [filter] - A bit mask for which rows to include.
-   * @param {Object} [groups] - Row grouping criteria.
+   * @param {object} [groups] - Row grouping criteria.
    * @param {string[]} [groups.names] - Output column names for grouping variables.
    * @param {function[]} [groups.get] - Accessor functions for grouping variables.
    * @param {function} [order] - A comparator function for sorting rows.
-   * @param {Object} [params] - Parameter values for table expressions.
+   * @param {object} [params] - Parameter values for table expressions.
    */
   constructor(names, nrows, data, filter, groups, order, params) {
     this._names = Object.freeze(names);
@@ -47,7 +47,7 @@ export default class Table {
    * The new table may have different data, filter, grouping, or ordering
    * based on the values of the optional configuration argument. If a
    * setting is not specified, it is inherited from the current table.
-   * @param {Object} [config] Configuration settings for the new table:
+   * @param {object} [config] Configuration settings for the new table:
    *  - data: The data payload to use.
    *  - names: An ordered list of column names.
    *  - filter: An additional filter bitset to apply.
@@ -104,7 +104,7 @@ export default class Table {
 
   /**
    * A table groupby specification.
-   * @typedef {Object} GroupBySpec
+   * @typedef {object} GroupBySpec
    * @property {number} size - The number of groups.
    * @property {string[]} names - Column names for each group.
    * @property {Function[]} get - Value accessor functions for each group.
@@ -216,7 +216,7 @@ export default class Table {
 
   /**
    * Options for generating row objects.
-   * @typedef {Object} ObjectsOptions
+   * @typedef {object} ObjectsOptions
    * @property {number} [limit=Infinity] The maximum number of objects to create.
    * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
    */
@@ -336,7 +336,7 @@ export default class Table {
    * Callback function invoked for each row of a table scan.
    * @callback scanVisitor
    * @param {number} row The table row index.
-   * @param {Object|Array} data The backing table data store.
+   * @param {object|Array} data The backing table data store.
    * @param {Function} stop Function to stop the scan early.
    *  Callees can invoke this function to prevent future calls.
    */
@@ -386,8 +386,8 @@ export default class Table {
    * as an object. Otherwise, adds the provided parameters to this
    * table's parameter set and returns the table. Any prior parameters
    * with names matching the input parameters are overridden.
-   * @param {Object} values The parameter values.
-   * @return {Table|Object} The current parameters values (if called with
+   * @param {object} values The parameter values.
+   * @return {Table|object} The current parameters values (if called with
    *  no arguments) or this table.
    */
   params(values) {
@@ -405,7 +405,7 @@ export default class Table {
 
   /**
    * Options for count transformations.
-   * @typedef {Object} CountOptions
+   * @typedef {object} CountOptions
    * @property {string} [as='count'] The name of the output count column.
    */
 
@@ -441,16 +441,16 @@ export default class Table {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} DeriveOptions
+   * @typedef {object} DeriveOptions
    * @property {boolean} [drop=false] A flag indicating if the original
    *  columns should be dropped, leaving only the derived columns. If true,
    *  the before and after options are ignored.
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -461,7 +461,7 @@ export default class Table {
    * Derive new column values based on the provided expressions. By default,
    * new columns are added after (higher indices than) existing columns. Use
    * the before or after options to place new columns elsewhere.
-   * @param {Object} values Object of name-value pairs defining the
+   * @param {object} values Object of name-value pairs defining the
    *  columns to derive. The input object should have output column
    *  names for keys and table expressions for values.
    * @param {DeriveOptions=} options Options for dropping or relocating
@@ -551,13 +551,13 @@ export default class Table {
 
   /**
    * Options for relocate transformations.
-   * @typedef {Object} RelocateOptions
-   * @property {string|string[]|number|number[]|Object|Function} [before]
+   * @typedef {object} RelocateOptions
+   * @property {string|string[]|number|number[]|object|Function} [before]
    *  An anchor column that relocated columns should be placed before.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the first column will be used as an anchor.
    *  It is an error to specify both before and after options.
-   * @property {string|string[]|number|number[]|Object|Function} [after]
+   * @property {string|string[]|number|number[]|object|Function} [after]
    *  An anchor column that relocated columns should be placed after.
    *  The value can be any legal column selection. If multiple columns are
    *  selected, only the last column will be used as an anchor.
@@ -567,7 +567,7 @@ export default class Table {
   /**
    * Relocate a subset of columns to change their positions, also
    * potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns An
+   * @param {string|string[]|number|number[]|object|Function} columns An
    * ordered selection of columns to relocate. The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -592,7 +592,7 @@ export default class Table {
    * Rollup a table to produce an aggregate summary.
    * Often used in conjunction with {@link Table#groupby}.
    * To produce counts only, {@link Table#count} is a convenient shortcut.
-   * @param {Object} values Object of name-value pairs defining aggregated
+   * @param {object} values Object of name-value pairs defining aggregated
    *  output columns. The input object should have output column
    *  names for keys and table expressions for values.
    * @return {Table} A new table of aggregate summary values.
@@ -605,7 +605,7 @@ export default class Table {
 
   /**
    * Options for sample transformations.
-   * @typedef {Object} SampleOptions
+   * @typedef {object} SampleOptions
    * @property {boolean} [replace=false] Flag for sampling with replacement.
    * @property {Function|string} [weight] Column values to use as weights
    *  for sampling. Rows will be sampled with probability proportional to
@@ -633,7 +633,7 @@ export default class Table {
 
   /**
    * Select a subset of columns into a new table, potentially renaming them.
-   * @param {string|string[]|number|number[]|Object|Function} columns The columns to select.
+   * @param {string|string[]|number|number[]|object|Function} columns The columns to select.
    *  The input may consist of:
    *  - column name strings,
    *  - column integer indices,
@@ -675,7 +675,7 @@ export default class Table {
 
   /**
    * Options for fold transformations.
-   * @typedef {Object} FoldOptions
+   * @typedef {object} FoldOptions
    * @property {string[]} [as=['key', 'value']] An array indicating the
    *  output column names to use for the key and value columns, respectively.
    */
@@ -703,7 +703,7 @@ export default class Table {
 
   /**
    * Options for pivot transformations.
-   * @typedef {Object} PivotOptions
+   * @typedef {object} PivotOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string} [keySeparator='_'] A string to place between multiple key names.
    * @property {string} [valueSeparator='_'] A string to place between key and value names.
@@ -723,7 +723,7 @@ export default class Table {
    * @param {*} keys Key values to map to new column names. Keys may be an
    *  array of column name strings, column index numbers, or value objects
    *  with output column names for keys and table expressions for values.
-   * @param {string|string[]|Object} values Output values for pivoted columns.
+   * @param {string|string[]|object} values Output values for pivoted columns.
    *  Column string names will be wrapped in any *any* aggregate.
    *  If object-valued, the input object should have output value
    *  names for keys and table expressions for values.
@@ -739,7 +739,7 @@ export default class Table {
 
   /**
    * Options for spread transformations.
-   * @typedef {Object} SpreadOptions
+   * @typedef {object} SpreadOptions
    * @property {number} [limit=Infinity] The maximum number of new columns to generate.
    * @property {string[]} [as] Output column names to use. This option only
    *  applies when a single column is spread. If the given array of names is
@@ -750,7 +750,7 @@ export default class Table {
   /**
    * Spread array elements into a set of new columns.
    * Output columns are named based on the value key and array index.
-   * @param {string|Array|Object} values The columns to spread, as either
+   * @param {string|Array|object} values The columns to spread, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {SpreadOptions=} [options] Options for spreading.
    * @return {Table} A new table with the spread columns added.
@@ -763,14 +763,14 @@ export default class Table {
 
   /**
    * Options for unroll transformations.
-   * @typedef {Object} UnrollOptions
+   * @typedef {object} UnrollOptions
    * @property {number} [limit=Infinity] The maximum number of new rows
    *  to generate per array value.
    * @property {boolean|string} [index=false] Flag or column name for adding
    *  zero-based array index values as an output column. If true, a new column
    *  named "index" will be included. If string-valued, a new column with
    *  the given name will be added.
-   * @property {string|string[]|number|number[]|Object|Function} [drop]
+   * @property {string|string[]|number|number[]|object|Function} [drop]
    *  A selection of columns to drop (exclude) from the unrolled output.
    *  The input may consist of:
    *  - column name strings,
@@ -786,7 +786,7 @@ export default class Table {
    * If more than one array value is used, the number of new rows
    * is the smaller of the limit and the largest length.
    * Values for all other columns are copied over.
-   * @param {string|Array|Object} values The columns to unroll, as either
+   * @param {string|Array|object} values The columns to unroll, as either
    *  an array of column names or a key-value object of table expressions.
    * @param {UnrollOptions=} [options] Options for unrolling.
    * @return {Table} A new unrolled table.
@@ -809,7 +809,7 @@ export default class Table {
    * @param {Array} on A two-element array of lookup keys (column name
    *  strings or table expressions) for this table and the secondary table,
    *  respectively.
-   * @param {string|Object} values The column values to add from the
+   * @param {string|object} values The column values to add from the
    *  secondary table. Can be column name strings or objects with column
    *  names as keys and table expressions as values.
    * @return {Table} A new table with lookup values added.
@@ -821,7 +821,7 @@ export default class Table {
 
   /**
    * Options for join transformations.
-   * @typedef {Object} JoinOptions
+   * @typedef {object} JoinOptions
    * @property {boolean} [left=false] Flag indicating a left outer join.
    *  If both the *left* and *right* are true, indicates a full outer join.
    * @property {boolean} [right=false] Flag indicating a right outer join.
@@ -852,7 +852,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -888,7 +888,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -926,7 +926,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -964,7 +964,7 @@ export default class Table {
    *  join key values can be arrays or objects, and that normal join
    *  semantics do not consider null or undefined values to be equal (that is,
    *  null !== null). Use the op.equal function to handle these cases.
-   * @param {Array|Object} [values] The columns to include in the join output.
+   * @param {Array|object} [values] The columns to include in the join output.
    *  If unspecified, all columns from both tables are included; paired
    *  join keys sharing the same column name are included only once.
    *  If array-valued, a two element array should be provided, containing
@@ -993,7 +993,7 @@ export default class Table {
    * This is a convenience method for {@link Table#join} in which the
    * join criteria is always true.
    * @param {Table} other The other (right) table to join with.
-   * @param {Array|Object} [values] The columns to include in the output.
+   * @param {Array|object} [values] The columns to include in the output.
    *  If unspecified, all columns from both tables are included.
    *  If array-valued, a two element array should be provided, containing
    *  the columns to include for the left and right tables, respectively.

--- a/src/verbs/expr/bin.js
+++ b/src/verbs/expr/bin.js
@@ -1,6 +1,6 @@
 /**
  * Options for binning number values.
- * @typedef {Object} BinOptions
+ * @typedef {object} BinOptions
  * @property {number} [maxbins] The maximum number of bins.
  * @property {number} [minstep] The minimum step size between bins.
  * @property {boolean} [nice=true] Flag indicating if bins should

--- a/src/verbs/expr/desc.js
+++ b/src/verbs/expr/desc.js
@@ -2,8 +2,8 @@ import wrap from './wrap';
 
 /**
  * Annotate a table expression to indicate descending sort order.
- * @param {string|Function|Object} expr The table expression to annotate.
- * @return {Object} A wrapped expression indicating descending sort.
+ * @param {string|Function|object} expr The table expression to annotate.
+ * @return {object} A wrapped expression indicating descending sort.
  * @example desc('colA')
  * @example desc(d => d.colA)
  */

--- a/src/verbs/expr/field.js
+++ b/src/verbs/expr/field.js
@@ -2,7 +2,7 @@ import wrap from './wrap';
 
 /**
  * Annotate an expression to indicate it is a string field reference.
- * @param {string|Object} expr The column name, or an existing wrapped
+ * @param {string|object} expr The column name, or an existing wrapped
  *  expression for a column name.
  * @param {string} [name] The column name to use. If provided, will
  *  overwrite the input expression value.

--- a/src/verbs/expr/rolling.js
+++ b/src/verbs/expr/rolling.js
@@ -5,7 +5,7 @@ import wrap from './wrap';
  * functions within a sliding window frame. For example, to specify a
  * rolling 7-day average centered on the current day, use rolling with
  * a frame value of [-3, 3].
- * @param {string|Function|Object} expr The table expression to annotate.
+ * @param {string|Function|object} expr The table expression to annotate.
  * @param {[number?, number?]} [frame=[-Infinity, 0]] The sliding window frame
  *  offsets. Each entry indicates an offset from the current value. If an
  *  entry is non-finite, the frame will be unbounded in that direction,

--- a/src/verbs/expr/wrap.js
+++ b/src/verbs/expr/wrap.js
@@ -2,9 +2,9 @@ import isFunction from '../../util/is-function';
 
 /**
  * Annotate an expression in an object wrapper.
- * @param {string|Function|Object} expr An expression to annotate.
- * @param {Object} properties The properties to annotate with.
- * @return {Object} A new wrapped expression object.
+ * @param {string|Function|object} expr An expression to annotate.
+ * @param {object} properties The properties to annotate with.
+ * @return {object} A new wrapped expression object.
  */
 export default function(expr, properties) {
   return expr && expr.expr

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -63,7 +63,7 @@ export {
 
 /**
  * Create a new table for a set of named columns.
- * @param {Object.<string, Array|TypedArray>} columns
+ * @param {object} columns
  *  The set of named column arrays.
  *  Object keys are the column names.
  *  The enumeration order of the keys determines the column indices.
@@ -81,7 +81,7 @@ export function table(columns, names) {
 /**
  * Create a new table from an existing object, such as an array of
  * objects or a set of key-value pairs.
- * @param {Object|Array|Map} values Data values to populate the table.
+ * @param {object|Array|Map} values Data values to populate the table.
  *  If array-valued or iterable, imports rows for each non-null value,
  *  using the provided column names as keys for each row object. If no
  *  names are provided, the first non-null object's own keys are used.


### PR DESCRIPTION
- Fix JSDoc types to use `object`, not `Object`.