### PR TITLE
Revise spread verb.

### DIFF
--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -562,40 +562,65 @@ Pivot columns into a cross-tabulation. The pivot transform is an inverse of the 
 *Examples*
 
 ```js
+// pivot the values in the 'key' column to be new column names
+// using the 'value' column as the new column values
+// the any() aggregate combines multiple values with the same key
 table.pivot('key', 'value')
 ```
 
 ```js
-table.pivot(['keyA', 'keyB'], ['valueA', 'valueB'])
+// pivot lowercase values of the 'key' column to be new column names
+// use the sum of corresponding 'value' entris as new column values
+table.pivot(
+  { key: d => op.lower(d.key) },
+  { value: d => op.sum(d.value) }
+)
 ```
 
 ```js
-table.pivot({ key: d => d.key }, { value: d => op.sum(d.value) })
+// pivot on key column 'type' and value columns ['x', 'y']
+// generates: { x_a: [0], x_b: [1], y_a: [3], y_b: [4] }
+aq.table({ type: ['a', 'b'], x: [1, 2], y: [3, 4 ]})
+  .pivot('type', ['x', 'y'])
 ```
 
+aq.table({ foo: ['a', 'b'], bar: ['u', 'v'], x: [1, 2], y: [3, 4 ]}).pivot(['foo', 'bar'], ['x', 'y'])
+
+aq.table({ keyA: [1, 2], keyB: [3, 4], valueA: [5, 6], valueB: [7, 8 ]})
 
 <hr/><a id="spread" href="#spread">#</a>
 <em>table</em>.<b>spread</b>(<i>values</i>[, <i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
-Spread array elements into a set of new columns. Output columns are named based on both the value key and array index.
+Spread array elements into a set of new columns. Output columns are named either according to the *as* option or using a combination of the input colum names and array index.
 
 * *values*: The columns to spread, as either an array of column names or a key-value object of table expressions.
 * *options*: An options object:
+  * *drop*: Boolean flag (default `true`) indicating if input columns to the spread operation should be dropped in the output table.
   * *limit*: The maximum number of new columns to generate (default `Infinity`).
-  * *as*: String array of output column names to use. This option only applies when a single column is spread. If the given array of names is shorter than the number of generated columns, the additional columns will be named using the standard naming convention.
+  * *as*: String array of output column names to use. This option only applies when a single column is spread. If the given array of names is shorter than the number of generated columns and no *limit* option is specified, the additional generated columns will be dropped (in other words, the length of the *as* array then serves as the limit value).
 
 *Examples*
 
 ```js
-table.spread({ a: d => op.split(d.text, '') })
+// generate new columns 'text_1', 'text_2', etc. by splitting on whitespace
+// the input column 'text' is dropped from the output
+table.spread({ text: d => op.split(d.text, ' ') })
 ```
 
 ```js
+// generate new columns 'text_1', 'text_2', etc. by splitting on whitespace
+// the input column 'text' is retained in the output
+table.spread({ text: d => op.split(d.text, ' ') }, { drop: false })
+```
+
+```js
+// spread the 'arrayCol' column across a maximum of 100 new columns
 table.spread('arrayCol', { limit: 100 })
 ```
 
 ```js
-table.spread('arrayCol', { limit: 2, as: ['value1', 'value2'] })
+// extract the first two 'arrayCol' entries into 'value1', 'value2' columns
+table.spread('arrayCol', { as: ['value1', 'value2'] })
 ```
 
 

--- a/src/engine/pivot.js
+++ b/src/engine/pivot.js
@@ -7,7 +7,7 @@ export default function(table, on, values, options = {}) {
   const { keys, keyColumn } = pivotKeys(table, on, options);
   const vsep = opt(options.valueSeparator, '_');
   const namefn = values.names.length > 1
-    ? (i, name) => keys[i] + vsep + name
+    ? (i, name) => name + vsep + keys[i]
     : i => keys[i];
 
   // perform separate aggregate operations for each key
@@ -26,9 +26,7 @@ export default function(table, on, values, options = {}) {
     )
     .map(ops => aggregate(table, ops));
 
-  return table.create(
-    output(table, values, namefn, results)
-  );
+  return table.create(output(table, values, namefn, results));
 }
 
 function pivotKeys(table, on, options) {

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -874,11 +874,14 @@ export default class Transformable {
 /**
  * Options for spread transformations.
  * @typedef {object} SpreadOptions
- * @property {number} [limit=Infinity] The maximum number of new columns to generate.
+ * @property {boolean} [drop=true] Flag indicating if input columns to the
+ *  spread operation should be dropped in the output table.
+ * @property {number} [limit=Infinity] The maximum number of new columns to
+ *  generate.
  * @property {string[]} [as] Output column names to use. This option only
  *  applies when a single column is spread. If the given array of names is
- *  shorter than the number of generated columns, the additional columns
- *  will be named using the standard naming convention.
+ *  shorter than the number of generated columns and no limit option is
+ *  specified, the additional generated columns will be dropped.
  */
 
 /**

--- a/test/query/query-test.js
+++ b/test/query/query-test.js
@@ -626,10 +626,23 @@ tape('Query evaluates spread verbs', t => {
       new Query([spread(['list'])]).toObject()
     ).evaluate(dt),
     {
+      'list_1': [1],
+      'list_2': [2],
+      'list_3': [3]
+    },
+    'spread query result, column names'
+  );
+
+  tableEqual(
+    t,
+    Query.from(
+      new Query([spread(['list'], { drop: false })]).toObject()
+    ).evaluate(dt),
+    {
       'list': [[1, 2, 3]],
-      'list1': [1],
-      'list2': [2],
-      'list3': [3]
+      'list_1': [1],
+      'list_2': [2],
+      'list_3': [3]
     },
     'spread query result, column names'
   );
@@ -640,10 +653,10 @@ tape('Query evaluates spread verbs', t => {
       new Query([spread([{ list: d => d.list }])]).toObject()
     ).evaluate(dt),
     {
-      'list': [[1, 2, 3]],
-      'list1': [1],
-      'list2': [2],
-      'list3': [3]
+      // 'list': [[1, 2, 3]],
+      'list_1': [1],
+      'list_2': [2],
+      'list_3': [3]
     },
     'spread query result, table expression'
   );
@@ -654,9 +667,9 @@ tape('Query evaluates spread verbs', t => {
       new Query([spread(['list'], { limit: 2 })]).toObject()
     ).evaluate(dt),
     {
-      'list': [[1, 2, 3]],
-      'list1': [1],
-      'list2': [2]
+      // 'list': [[1, 2, 3]],
+      'list_1': [1],
+      'list_2': [2]
     },
     'spread query result, limit'
   );

--- a/test/verbs/pivot-test.js
+++ b/test/verbs/pivot-test.js
@@ -55,12 +55,12 @@ tape('pivot generates cross-tabulation for multiple values', t => {
   });
 
   tableEqual(t, ut, {
-    a_x: [ 1 ],
-    b_x: [ 4 ],
-    c_x: [ 3 ],
-    a_y: [ 9 ],
-    b_y: [ 4 ],
-    c_y: [ 7 ]
+    x_a: [ 1 ],
+    x_b: [ 4 ],
+    x_c: [ 3 ],
+    y_a: [ 9 ],
+    y_b: [ 4 ],
+    y_c: [ 7 ]
   }, 'pivot data');
 
   t.end();
@@ -81,10 +81,10 @@ tape('pivot respects input options', t => {
   });
 
   tableEqual(t, ut, {
-    'a/d:x': [ 1 ],
-    'b/e:x': [ 2 ],
-    'a/d:y': [ 9 ],
-    'b/e:y': [ 8 ]
+    'x:a/d': [ 1 ],
+    'x:b/e': [ 2 ],
+    'y:a/d': [ 9 ],
+    'y:b/e': [ 8 ]
   }, 'pivot data');
 
   t.end();

--- a/test/verbs/spread-test.js
+++ b/test/verbs/spread-test.js
@@ -14,8 +14,8 @@ tape('spread produces multiple columns from arrays', t => {
 
   tableEqual(t, dt, {
     ...data,
-    split1: [ 'foo', 'foo', 'bar', 'baz' ],
-    split2: [ 'bar', null, 'baz', 'bop' ]
+    split_1: [ 'foo', 'foo', 'bar', 'baz' ],
+    split_2: [ 'bar', undefined, 'baz', 'bop' ]
   }, 'spread data');
   t.end();
 });
@@ -25,12 +25,12 @@ tape('spread supports column name argument', t => {
     list: [['foo', 'bar', 'bop'], ['foo'], ['bar', 'baz'], ['baz', 'bop']]
   };
 
-  const dt = table(data).spread('list', { limit: 2 });
+  const dt = table(data).spread('list', { drop: false, limit: 2 });
 
   tableEqual(t, dt, {
     ...data,
-    list1: [ 'foo', 'foo', 'bar', 'baz' ],
-    list2: [ 'bar', null, 'baz', 'bop' ]
+    list_1: [ 'foo', 'foo', 'bar', 'baz' ],
+    list_2: [ 'bar', undefined, 'baz', 'bop' ]
   }, 'spread data');
   t.end();
 });
@@ -43,9 +43,8 @@ tape('spread supports column index argument', t => {
   const dt = table(data).spread(0, { limit: 2 });
 
   tableEqual(t, dt, {
-    ...data,
-    list1: [ 'foo', 'foo', 'bar', 'baz' ],
-    list2: [ 'bar', null, 'baz', 'bop' ]
+    list_1: [ 'foo', 'foo', 'bar', 'baz' ],
+    list_2: [ 'bar', undefined, 'baz', 'bop' ]
   }, 'spread data');
   t.end();
 });
@@ -59,11 +58,10 @@ tape('spread supports multiple input columns', t => {
   const dt = table(data).spread(['a', 'b'], { limit: 2 });
 
   tableEqual(t, dt, {
-    ...data,
-    a1: [ 'foo', 'foo', 'bar', 'baz' ],
-    a2: [ 'bar', null, 'baz', 'bop' ],
-    b1: [ 'baz', 'bar', 'foo', 'foo' ],
-    b2: [ 'bop', 'baz', null, 'bar' ]
+    a_1: [ 'foo', 'foo', 'bar', 'baz' ],
+    a_2: [ 'bar', undefined, 'baz', 'bop' ],
+    b_1: [ 'baz', 'bar', 'foo', 'foo' ],
+    b_2: [ 'bop', 'baz', undefined, 'bar' ]
   }, 'spread data');
   t.end();
 });
@@ -73,18 +71,18 @@ tape('spread supports as option with single column input', t => {
     list: [['foo', 'bar', 'bop'], ['foo'], ['bar', 'baz'], ['baz', 'bop']]
   };
 
-  const dt = table(data).spread('list', { limit: 2, as: ['bip', 'bop'] });
+  const dt = table(data).spread('list', { as: ['bip', 'bop'] });
 
   tableEqual(t, dt, {
-    ...data,
     bip: [ 'foo', 'foo', 'bar', 'baz' ],
-    bop: [ 'bar', null, 'baz', 'bop' ]
+    bop: [ 'bar', undefined, 'baz', 'bop' ]
   }, 'spread data with as');
   t.end();
 });
 
 tape('spread ignores as option with multi column input', t => {
   const data = {
+    key: ['a', 'b', 'c', 'd'],
     a: [['foo', 'bar', 'bop'], ['foo'], ['bar', 'baz'], ['baz', 'bop']],
     b: [['baz', 'bop'], ['bar', 'baz'], ['foo'], ['foo', 'bar', 'bop']]
   };
@@ -92,11 +90,11 @@ tape('spread ignores as option with multi column input', t => {
   const dt = table(data).spread(['a', 'b'], { limit: 2, as: ['bip', 'bop'] });
 
   tableEqual(t, dt, {
-    ...data,
-    a1: [ 'foo', 'foo', 'bar', 'baz' ],
-    a2: [ 'bar', null, 'baz', 'bop' ],
-    b1: [ 'baz', 'bar', 'foo', 'foo' ],
-    b2: [ 'bop', 'baz', null, 'bar' ]
+    key: ['a', 'b', 'c', 'd'],
+    a_1: [ 'foo', 'foo', 'bar', 'baz' ],
+    a_2: [ 'bar', undefined, 'baz', 'bop' ],
+    b_1: [ 'baz', 'bar', 'foo', 'foo' ],
+    b_2: [ 'bop', 'baz', undefined, 'bar' ]
   }, 'spread data with as');
   t.end();
 });


### PR DESCRIPTION
- Add `drop` option to `spread()` verb to drop input columns, set default to true.
- Revise `spread()` to use `undefined` for missing values.
- Revise `spread()` to use `_` separator between column name and index number in auto-generated names.
- Revise `spread()` to use the length of the `as` option as an implicit limit when `limit` is unspecified.