### PR TITLE
Fix date handling in aggregate functions.

### DIFF
--- a/src/util/distinct-map.js
+++ b/src/util/distinct-map.js
@@ -1,0 +1,30 @@
+import isDate from './is-date';
+
+function key(value) {
+  return isDate(value) ? '#date:' + +value : value;
+}
+
+export default function() {
+  const map = new Map();
+  return {
+    count() {
+      return map.size;
+    },
+    values() {
+      return Array.from(map.values(), _ => _.v);
+    },
+    increment(v) {
+      const k = key(v);
+      const e = map.get(k);
+      e ? ++e.n : map.set(k, { v, n: 1 });
+    },
+    decrement(v) {
+      const k = key(v);
+      const e = map.get(k);
+      e.n === 1 ? map.delete(k) : --e.n;
+    },
+    forEach(fn) {
+      map.forEach(({ v, n }) => fn(v, n));
+    }
+  };
+}

--- a/src/util/entries.js
+++ b/src/util/entries.js
@@ -4,5 +4,6 @@ import isMap from './is-map';
 export default function(value) {
   return isArray(value) ? value
     : isMap(value) ? value.entries()
-    : Object.entries(value);
+    : value ? Object.entries(value)
+    : [];
 }

--- a/src/util/is-date.js
+++ b/src/util/is-date.js
@@ -1,5 +1,3 @@
-import toString from './object-to-string';
-
 export default function(value) {
-  return toString.call(value) === '[object Date]';
+  return value instanceof Date;
 }

--- a/src/util/is-regexp.js
+++ b/src/util/is-regexp.js
@@ -1,5 +1,3 @@
-import toString from './object-to-string';
-
 export default function(value) {
-  return toString.call(value) === '[object RegExp]';
+  return value instanceof RegExp;
 }

--- a/src/util/object-to-string.js
+++ b/src/util/object-to-string.js
@@ -1,1 +1,0 @@
-export default Object.prototype.toString;


### PR DESCRIPTION
- Fix `distinct`, `unique`, and `mode` aggregates to group dates with the same timestamp.
- Fix `entries` utility to return empty array for null input.
- Update `isDate` and `isRegExp` utilities to be more performant.