### PR TITLE
Update JSDoc typings.

### DIFF
--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -31,30 +31,102 @@ title: Table \| Arquero API Reference
 
 The number of columns in this table.
 
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .numCols() // 2
+```
+
 <hr/><a id="numRows" href="#numRows">#</a>
 <em>table</em>.<b>numRows</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
 The number of active (non-filtered) rows in this table. This number may be less than the [total rows](#totalRows) if the table has been filtered.
+
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .numRows() // 3
+```
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .filter(d => d.a > 2)
+  .numRows() // 1
+```
 
 <hr/><a id="totalRows" href="#totalRows">#</a>
 <em>table</em>.<b>totalRows</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
 The total number of rows in this table, including both filtered and unfiltered rows.
 
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .totalRows() // 3
+```
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .filter(d => d.a > 2)
+  .totalRows() // 3
+```
+
 <hr/><a id="isFiltered" href="#isFiltered">#</a>
 <em>table</em>.<b>isFiltered</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
 Indicates if the table has a filter applied.
+
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .isFiltered() // false
+```
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .filter(d => d.a > 2)
+  .isFiltered() // true
+```
 
 <hr/><a id="isGrouped" href="#isGrouped">#</a>
 <em>table</em>.<b>isGrouped</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
 Indicates if the table has a groupby specification.
 
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .isGrouped() // false
+```
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .groupby('a')
+  .isGrouped() // true
+```
+
 <hr/><a id="isOrdered" href="#isOrdered">#</a>
 <em>table</em>.<b>isOrdered</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
 Indicates if the table has a row order comparator.
+
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .isOrdered() // false
+```
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .orderby(aq.desc('b'))
+  .isOrdered() // true
+```
 
 <hr/><a id="comparator" href="#comparator">#</a>
 <em>table</em>.<b>comparator</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
@@ -97,12 +169,26 @@ Get the column instance with the given name, or `undefined` if does not exist. T
 
 * *name*: The column name.
 
+*Examples*
+
+```js
+const dt = aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+dt.column('b').get(1) // 5
+```
+
 <hr/><a id="columnAt" href="#columnAt">#</a>
 <em>table</em>.<b>columnAt</b>(<i>index</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
 
 Get the column instance at the given index position, or `undefined` if does not exist. The returned column object provides a lightweight abstraction over the column storage (such as a backing array), providing a *length* property and *get(row)* method.
 
 * *index*: The zero-based column index.
+
+*Examples*
+
+```js
+const dt = aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+dt.columnAt(1).get(1) // 5
+```
 
 <hr/><a id="columnIndex" href="#columnIndex">#</a>
 <em>table</em>.<b>columnIndex</b>(<i>name</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
@@ -111,12 +197,24 @@ The column index for the given name, or `-1` if the name is not found.
 
 * *name*: The column name.
 
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).columnIndex('b'); // 1
+```
+
 <hr/><a id="columnName" href="#columnName">#</a>
 <em>table</em>.<b>columnName</b>(<i>index</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
 The column name at the given index, or `undefined` if the index is out of range.
 
 * *index*: The column index.
+
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).columnName(1); // 'b'
+```
 
 <hr/><a id="columnNames" href="#columnNames">#</a>
 <em>table</em>.<b>columnNames</b>([<i>filter</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
@@ -128,6 +226,11 @@ Returns an array of table column names, optionally filtered.
   * *index*: The column index.
   * *array*: The backing array of names.
 
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).columnNames(); // [ 'a', 'b' ]
+```
 
 <br/>
 
@@ -146,10 +249,26 @@ Get the value for the given column and row. Row indices are relative to the [tot
 * *name*: The column name.
 * *row*: The row index.
 
+*Examples*
+
+```js
+const dt = aq.table({ a: [1, 2, 3], b: [4, 5, 6] });
+dt.get('a', 0) // 1
+dt.get('a', 2) // 3
+```
+
 <hr/><a id="getter" href="#getter">#</a>
 <em>table</em>.<b>getter</b>(<i>name</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
 
 Returns an accessor ("getter") function for a column. The returned function takes a row index as its single argument and returns the corresponding column value. Row indices are relative to the [total rows](#totalRows), not the number of [filtered rows](#numRows).
+
+*Examples*
+
+```js
+const get = aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).getter('a');
+get(0) // 1
+get(2) // 3
+```
 
 * *name*: The column name.
 
@@ -192,10 +311,18 @@ Returns an array of objects representing table rows. A new set of objects will b
   * *limit*: The maximum number of objects to create (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
 
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).objects()
+// [ { a: 1, b: 4 }, { a: 2, b: 5 }, { a: 3, b: 6 } ]
+}
+```
+
 <hr/><a id="@@iterator" href="#@@iterator">#</a>
 <em>table</em>\[<b>Symbol.iterator</b>\]() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
 
-Returns an iterator over generated row objects. Similar to the [objects](#objects) method, this method generates new row object instances; however, rather than returning an array, this method provides an iterator over row objects for each active row in the table.
+Returns an iterator over generated row objects. Similar to the [objects](#objects) method, this method generates new row object instances; however, rather than returning an array, this method provides an iterator over row objects for each non-filtered row in the table.
 
 *Examples*
 
@@ -215,21 +342,42 @@ const objects = [...table];
 
 Print the contents of this table using the `console.table()` method.
 
-* *options*: Options for printing, typically an object value. If number-valued, the call is equivalent to `{ limit: value }`.
+* *options*: Options for printing. If number-valued, specifies the row limit (equivalent to `{ limit: value }`).
   * *limit*: The maximum number of rows to print (default `10`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
+
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).print()
+// ┌─────────┬───┬───┐
+// │ (index) │ a │ b │
+// ├─────────┼───┼───┤
+// │    0    │ 1 │ 4 │
+// │    1    │ 2 │ 5 │
+// │    2    │ 3 │ 6 │
+// └─────────┴───┴───┘
+```
 
 <hr/><a id="toCSV" href="#toCSV">#</a>
 <em>table</em>.<b>toCSV</b>([<i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/to-csv.js)
 
-Format this table as a comma-separated values (CSV) string. Other delimiters, such as tabs or pipes ('\|'), can be specified using the options argument.
+Format this table as a comma-separated values (CSV) string. Other delimiters, such as tabs or pipes ('\|'), can be specified using the *options* argument.
 
 * *options*: A formatting options object:
   * *delimiter*: The delimiter between values (default `","`).
   * *limit*: The maximum number of rows to print (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
-  * *columns*: Ordered list of column names to include. If function-valued, the function should accept a table as input and return an array of column name strings.
-  * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions to invoke to transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
+  * *columns*: Ordered list of column names to include. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
+  * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions that transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
+
+*Examples*
+
+```js
+// serialize a table as CSV-formatted text
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).toCSV()
+// 'a,b\n1,4\n2,5\n3,6'
+```
 
 <hr/><a id="toHTML" href="#toHTML">#</a>
 <em>table</em>.<b>toHTML</b>([<i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/to-csv.js)
@@ -239,13 +387,21 @@ Format this table as an HTML table string.
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
-  * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
+  * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
-  * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:
-    * *date*: One of 'utc' or 'loc' (for UTC or local dates), or `null` for complete date time strings.
-    * *digits*: Number of significant digits to include for numbers.
+  * *format*: Object of column format options. If specified, these override any automatically inferred options. The object keys should be column names. The object values should either be formatting functions or objects with any of the following properties:
+    * *utc*: A boolean flag indicating if UTC date formatting should be used rather than the local time zone.
+    * *digits*: Number of fractional digits to include for numbers.
+  * *maxdigits*: The maximum number of fractional digits to include when inferring a number format (default `6`). This option is passed to the format inference method and is ignored when explicit format options are specified.
   * *null*: Optional format function for `null` and `undefined` values. If specified, this function be invoked with the `null` or `undefined` value as the sole input argument. The return value is then used as the HTML output for the input value.
-  * *style*: CSS styles to include in HTML output. The object keys can be HTML table tag names: `'table'`, `'thead'`, `'tbody'`, `'tr'`, `'th'`, or `'td'`. The object values should be strings of valid CSS style directives (such as `"font-weight: bold;"`) or functions that take a column name and row as inputs and return a CSS string.
+  * *style*: CSS styles to include in HTML output. The object keys can be HTML table tag names: `'table'`, `'thead'`, `'tbody'`, `'tr'`, `'th'`, or `'td'`. The object values should be strings of valid CSS style directives (such as `"font-weight: bold;"`) or functions that take a column name and row as input and return a CSS string.
+
+*Examples*
+
+```js
+// serialize a table as HTML-formatted text
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).toHTML()
+```
 
 <hr/><a id="toJSON" href="#toJSON">#</a>
 <em>table</em>.<b>toJSON</b>([<i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/format/to-json.js)
@@ -256,20 +412,20 @@ Format this table as a JavaScript Object Notation (JSON) string compatible with 
   * *limit*: The maximum number of rows to print (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *schema*: Boolean flag (default `true`) indicating if table schema metadata should be included in the JSON output. If `false`, only the data payload is included.
-  * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
-  * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions to invoke to transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
+  * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
+  * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions that transform column values prior to output. If specified, a formatting function overrides any automatically inferred options.
 
 *Examples*
 
 ```js
-// serialize a table to a JSON string with schema metadata
-aq.table({ a: [1, 2, 3], b: [4, 5,6] }).toJSON()
+// serialize a table as a JSON string with schema metadata
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).toJSON()
 // '{"schema":{"fields":[{"name":"a"},{"name":"b"}]},"data":{"a":[1,2,3],"b":[4,5,6]}}'
 ```
 
 ```js
-// serialize a table to a JSON string without schema metadata
-aq.table({ a: [1, 2, 3], b: [4, 5,6] }).toJSON({ schema: false })
+// serialize a table as a JSON string without schema metadata
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).toJSON({ schema: false })
 // '{"a":[1,2,3],"b":[4,5,6]}'
 ```
 
@@ -281,8 +437,17 @@ Format this table as a [GitHub-Flavored Markdown table](https://github.github.co
 * *options*: A formatting options object:
   * *limit*: The maximum number of rows to print (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
-  * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings.
+  * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
-  * *format*: Object of column format options. The object keys should be column names. The object values should be formatting functions or objects with any of the following properties.If specified, these override any automatically inferred options:
-    * *date*: One of 'utc' or 'loc' (for UTC or local dates), or `null` for complete date time strings.
-    * *digits*: Number of significant digits to include for numbers.
+  * *format*: Object of column format options. If specified, these override any automatically inferred options. The object keys should be column names. The object values should either be formatting functions or objects with any of the following properties:
+    * *utc*: A boolean flag indicating if UTC date formatting should be used rather than the local time zone.
+    * *digits*: Number of fractional digits to include for numbers.
+  * *maxdigits*: The maximum number of fractional digits to include when inferring a number format (default `6`). This option is passed to the format inference method and is ignored when explicit format options are specified.
+
+*Examples*
+
+```js
+// serialize a table as Markdown-formatted text
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).toMarkdown()
+// '|a|b|\n|-:|-:|\n|1|4|\n|2|5|\n|3|6|\n'
+```

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -200,7 +200,8 @@ The column index for the given name, or `-1` if the name is not found.
 *Examples*
 
 ```js
-aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).columnIndex('b'); // 1
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .columnIndex('b'); // 1
 ```
 
 <hr/><a id="columnName" href="#columnName">#</a>
@@ -213,7 +214,8 @@ The column name at the given index, or `undefined` if the index is out of range.
 *Examples*
 
 ```js
-aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).columnName(1); // 'b'
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .columnName(1); // 'b'
 ```
 
 <hr/><a id="columnNames" href="#columnNames">#</a>
@@ -229,7 +231,8 @@ Returns an array of table column names, optionally filtered.
 *Examples*
 
 ```js
-aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).columnNames(); // [ 'a', 'b' ]
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .columnNames(); // [ 'a', 'b' ]
 ```
 
 <br/>

--- a/src/format/from-arrow.js
+++ b/src/format/from-arrow.js
@@ -22,12 +22,11 @@ function isStruct(id) {
 /**
  * Options for Apache Arrow import.
  * @typedef {object} ArrowOptions
- * @property {string|string[]|number|number[]|object|Function} columns
- *  An ordered set of columns to import. The input may consist of:
- *  - column name strings,
- *  - column integer indices,
- *  - objects with current column names as keys and new column names as values (for renaming), or
- *  - selection helper functions such as {@link all}, {@link not}, or {@link range}.
+ * @property {import('../table/transformable').Select} columns
+ *  An ordered set of columns to import. The input may consist of column name
+ *  strings, column integer indices, objects with current column names as keys
+ *  and new column names as values (for renaming), or selection helper
+ *  functions such as {@link all}, {@link not}, or {@link range}.
  * @property {boolean} [unpack=false] Flag to unpack binary-encoded Arrow
  *  data to standard JavaScript values. Unpacking can incur an upfront time
  *  and memory cost to extract data to new arrays, but can speed up later

--- a/src/format/from-csv.js
+++ b/src/format/from-csv.js
@@ -15,9 +15,9 @@ const DEFAULT_COLUMN_NAME = 'col';
  *  If true, assumes the CSV contains a header row with column names.
  *  If false, indicates the CSV does not contain a header row, and the
  *  columns are given the names 'col1', 'col2', and so on.
- * @property {object} [parse] Object of column parsing options.
- *  The object keys should be column names. The object values should be
- *  parsing functions to invoke to transform values upon input.
+ * @property {Object.<string, (value: string) => any>} [parse] Object of
+ *  column parsing options. The object keys should be column names. The object
+ *  values should be parsing functions that transform values upon input.
  */
 
 /**

--- a/src/format/from-json.js
+++ b/src/format/from-json.js
@@ -16,9 +16,9 @@ function autoType(key, value) {
  * @typedef {object} JSONParseOptions
  * @property {boolean} [autoType=true] Flag controlling automatic type
  *  inference. If false, date parsing for input JSON strings is disabled.
- * @property {object} [parse] Object of column parsing options.
- *  The object keys should be column names. The object values should be
- *  parsing functions to invoke to transform values upon input.
+ * @property {Object.<string, (value: any) => any>} [parse] Object of column
+ *  parsing options. The object keys should be column names. The object values
+ *  should be parsing functions that transform values upon input.
  */
 
 /**

--- a/src/format/to-csv.js
+++ b/src/format/to-csv.js
@@ -8,13 +8,13 @@ import isDate from '../util/is-date';
  * @property {string} [delimiter=','] The delimiter between values.
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
- * @property {string[]|Function} [columns] Ordered list of column names
- *  to include. If function-valued, the function should accept a table as
- *  input and return an array of column name strings.
- * @property {object} [format] Object of column format options.
- *  The object keys should be column names. The object values should be
- *  formatting functions to invoke to transform column values prior to output.
- *  If specified, these override any automatically inferred options.
+ * @property {import('./util').ColumnSelectOptions} [columns] Ordered list
+ *  of column names to include. If function-valued, the function should
+ *  accept a table as input and return an array of column name strings.
+ * @property {Object.<string, (value: any) => any>} [format] Object of column
+ *  format options. The object keys should be column names. The object values
+ *  should be formatting functions to invoke to transform column values prior
+ *  to output. If specified, these override automatically inferred options.
  */
 
 /**

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -48,6 +48,9 @@ import mapObject from '../util/map-object';
  *  'tbody', 'tr', 'th', or 'td'. The object values should be strings of
  *  valid CSS style directives (such as "font-weight: bold;") or functions
  *  that take a column name and row as inputs and return a CSS string.
+ * @property {number} [maxdigits=6] The maximum number of fractional digits
+ *  to include when formatting numbers. This option is passed to the format
+ *  inference method and is overridden by any explicit format options.
  */
 
 /**

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -4,26 +4,46 @@ import isFunction from '../util/is-function';
 import mapObject from '../util/map-object';
 
 /**
+ * Null format function.
+ * @callback NullFormat
+ * @param {null|undefined} [value] The value to format.
+ * @return {string} The formatted HTML string.
+ */
+
+/**
+ * CSS style function.
+ * @callback StyleFunction
+ * @param {string} name The column name.
+ * @param {number} row The table row index.
+ * @return {string} A CSS style string.
+ */
+
+/**
+ * CSS style options.
+ * @typedef {Object.<string, string | StyleFunction>} StyleOptions
+ */
+
+/**
  * Options for HTML formatting.
- * @typedef {object} HTMLOptions
+ * @typedef {object} HTMLFormatOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
- * @property {string[]} [columns] Ordered list of column names to print.
- * @property {object} [align] Object of column alignment options.
- *  The object keys should be column names. The object values should be
- *  aligment strings, one of 'l' (left), 'c' (center), or 'r' (right).
- *  If specified, these override the automatically inferred options.
- * @property {object} [format] Object of column format options.
- *  The object keys should be column names. The object values should be
- *  formatting functions or objects with any of the following properties.
- *  If specified, these override the automatically inferred options.
- *  - {string} date One of 'utc' or 'loc' (for UTC or local dates), or null for full date times.
- *  - {number} digits Number of significant digits to include for numbers.
- * @property {Function} [null] Format function for null and undefined values.
+ * @property {import('./util').ColumnSelectOptions} [columns] Ordered list
+ *  of column names to include. If function-valued, the function should
+ *  accept a table as input and return an array of column name strings.
+ * @property {import('./util').ColumnAlignOptions} [align] Object of column
+ *  alignment options. The object keys should be column names. The object
+ *  values should be aligment strings, one of 'l' (left), 'c' (center), or
+ *  'r' (right). If specified, these override automatically inferred options.
+ * @property {import('./util').ColumnFormatOptions} [format] Object of column
+ *  format options. The object keys should be column names. The object values
+ *  should be formatting functions or specification objects. If specified,
+ *  these override automatically inferred options.
+ * @property {NullFormat} [null] Format function for null or undefined values.
  *  If specified, this function will be invoked with the null or undefined
  *  value as the sole input, and the return value will be used as the HTML
  *  output for the value.
- * @property {object} [style] CSS styles to include in HTML output.
+ * @property {StyleOptions} [style] CSS styles to include in HTML output.
  *  The object keys should be HTML table tag names: 'table', 'thead',
  *  'tbody', 'tr', 'th', or 'td'. The object values should be strings of
  *  valid CSS style directives (such as "font-weight: bold;") or functions
@@ -33,7 +53,7 @@ import mapObject from '../util/map-object';
 /**
  * Format a table as an HTML table string.
  * @param {ColumnTable} table The table to format.
- * @param {HTMLOptions} options The formatting options.
+ * @param {HTMLFormatOptions} options The formatting options.
  * @return {string} An HTML table string.
  */
 export default function(table, options = {}) {

--- a/src/format/to-json.js
+++ b/src/format/to-json.js
@@ -12,13 +12,13 @@ import isDate from '../util/is-date';
  * @property {boolean} [schema=true] Flag indicating if table schema metadata
  *  should be included in the JSON output. If false, only the data payload
  *  is included.
- * @property {string[]|Function} [columns] Ordered list of column names
- *  to include. If function-valued, the function should accept a table as
- *  input and return an array of column name strings.
- * @property {object} [format] Object of column format options. The object
- *  keys should be column names. The object values should be formatting
- *  functions to invoke to transform column values prior to output. If
- *  specified, these override any automatically inferred options.
+ * @property {import('./util').ColumnSelectOptions} [columns] Ordered list
+ *  of column names to include. If function-valued, the function should
+ *  accept a table as input and return an array of column name strings.
+ * @property {Object.<string, (value: any) => any>} [format] Object of column
+ *  format options. The object keys should be column names. The object values
+ *  should be formatting functions to invoke to transform column values prior
+ *  to output. If specified, these override automatically inferred options.
  */
 
 const defaultFormatter = value => isDate(value)

--- a/src/format/to-markdown.js
+++ b/src/format/to-markdown.js
@@ -3,26 +3,26 @@ import { columns, formats, scan } from './util';
 
 /**
  * Options for Markdown formatting.
- * @typedef {object} MarkdownOptions
+ * @typedef {object} MarkdownFormatOptions
  * @property {number} [limit=Infinity] The maximum number of rows to print.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
- * @property {string[]} [columns] Ordered list of column names to print.
- * @property {object} [align] Object of column alignment options.
- *  The object keys should be column names. The object values should be
- *  aligment strings, one of 'l' (left), 'c' (center), or 'r' (right).
- *  If specified, these override the automatically inferred options.
- * @property {object} [format] Object of column format options.
- *  The object keys should be column names. The object values should be
- *  formatting functions or objects with any of the following properties.
- *  If specified, these override the automatically inferred options.
- *  - {string} date One of 'utc' or 'loc' (for UTC or local dates), or null for full date times.
- *  - {number} digits Number of significant digits to include for numbers.
+ * @property {import('./util').ColumnSelectOptions} [columns] Ordered list
+ *  of column names to include. If function-valued, the function should
+ *  accept a table as input and return an array of column name strings.
+ * @property {import('./util').ColumnAlignOptions} [align] Object of column
+ *  alignment options. The object keys should be column names. The object
+ *  values should be aligment strings, one of 'l' (left), 'c' (center), or
+ *  'r' (right). If specified, these override automatically inferred options.
+ * @property {import('./util').ColumnFormatOptions} [format] Object of column
+ *  format options. The object keys should be column names. The object values
+ *  should be formatting functions or specification objects. If specified,
+ *  these override automatically inferred options.
  */
 
 /**
  * Format a table as a GitHub-Flavored Markdown table string.
  * @param {ColumnTable} table The table to format.
- * @param {MarkdownOptions} options The formatting options.
+ * @param {MarkdownFormatOptions} options The formatting options.
  * @return {string} A GitHub-Flavored Markdown table string.
  */
 export default function(table, options = {}) {

--- a/src/format/to-markdown.js
+++ b/src/format/to-markdown.js
@@ -17,6 +17,9 @@ import { columns, formats, scan } from './util';
  *  format options. The object keys should be column names. The object values
  *  should be formatting functions or specification objects. If specified,
  *  these override automatically inferred options.
+ * @property {number} [maxdigits=6] The maximum number of fractional digits
+ *  to include when formatting numbers. This option is passed to the format
+ *  inference method and is overridden by any explicit format options.
  */
 
 /**

--- a/src/format/util.js
+++ b/src/format/util.js
@@ -1,6 +1,36 @@
 import inferFormat from './infer';
 import isFunction from '../util/is-function';
 
+/**
+ * Data table.
+ * @typedef {typeof import('../table/table')} Table
+ */
+
+/**
+ * Column selection function.
+ * @typedef {(table: Table) => string[]} ColumnSelectFunction
+ */
+
+/**
+ * Column selection options.
+ * @typedef {string[]|ColumnSelectFunction} ColumnSelectOptions
+ */
+
+/**
+ * Column format options. The object keys should be column names.
+ * The object values should be formatting functions or objects.
+ * If specified, these override any automatically inferred options.
+ * @typedef {Object.<string, import('./value').ValueFormatOptions} ColumnFormatOptions
+ */
+
+/**
+ * Column alignment options. The object keys should be column names.
+ * The object values should be aligment strings, one of 'l' (left),
+ * 'c' (center), or 'r' (right).
+ * If specified, these override any automatically inferred options.
+ * @typedef {Object.<string, 'l'|'c'|'r'>} ColumnAlignOptions
+ */
+
 export function columns(table, names) {
   return isFunction(names)
     ? names(table)

--- a/src/format/value.js
+++ b/src/format/value.js
@@ -3,6 +3,33 @@ import isDate from '../util/is-date';
 import isFunction from '../util/is-function';
 import isTypedArray from '../util/is-typed-array';
 
+/**
+ * Column format object.
+ * @typedef {object} ValueFormatObject
+ * @property {boolean} [utc=false] If true, format dates in UTC time.
+ * @property {number} [digits=0] The number of fractional digits to include
+ *  when formatting numbers.
+ * @property {number} [maxlen=30] The maximum string length for formatting
+ *  nested object or array values.
+ */
+
+/**
+ * @callback ValueFormatFunction
+ * @param {*} value The value to format.
+ * @return {*} A string-coercible or JSON-compatible formatted value.
+ */
+
+/**
+ * Value format options.
+ * @typedef {ValueFormatObject|ValueFormatFunction} ValueFormatOptions
+ */
+
+/**
+ * Format a value as a string.
+ * @param {*} v The value to format.
+ * @param {ValueFormatOptions} options Formatting options.
+ * @return {string} The formatted string.
+ */
 export default function(v, options = {}) {
   if (isFunction(options)) {
     return options(v) + '';

--- a/src/table/bit-set.js
+++ b/src/table/bit-set.js
@@ -1,17 +1,32 @@
 const ONE = 0x80000000;
 const ALL = 0xFFFFFFFF;
 
+/**
+ * Represent an indexable set of bits.
+ */
 export default class BitSet {
+  /**
+   * Instantiate a new BitSet instance.
+   * @param {number} size The number of bits.
+   */
   constructor(size) {
     this._size = size;
     this._bits = new Uint32Array(Math.ceil(size / 32));
   }
 
+  /**
+   * The number of bits.
+   * @return {number}
+   */
   get length() {
     return this._size;
   }
 
-  // https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
+  /**
+   * The number of bits set to one.
+   * https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetKernighan
+   * @return {number}
+   */
   count() {
     const n = this._bits.length;
     let count = 0;
@@ -23,24 +38,45 @@ export default class BitSet {
     return count;
   }
 
+  /**
+   * Get the bit at a given index.
+   * @param {number} i The bit index.
+   */
   get(i) {
     return this._bits[i >> 5] & (ONE >>> i);
   }
 
+  /**
+   * Set the bit at a given index to one.
+   * @param {number} i The bit index.
+   */
   set(i) {
     this._bits[i >> 5] |= (ONE >>> i);
   }
 
+  /**
+   * Clear the bit at a given index to zero.
+   * @param {number} i The bit index.
+   */
   clear(i) {
     this._bits[i >> 5] &= ~(ONE >>> i);
   }
 
+  /**
+   * Scan the bits, invoking a callback function with the index of
+   * each non-zero bit.
+   * @param {(i: number) => vois} fn A callback function.
+   */
   scan(fn) {
     for (let i = this.next(0); i >= 0; i = this.next(i + 1)) {
       fn(i);
     }
   }
 
+  /**
+   * Get the next non-zero bit starting from a given index.
+   * @param {number} i The bit index.
+   */
   next(i) {
     const bits = this._bits;
     const n = bits.length;
@@ -57,12 +93,22 @@ export default class BitSet {
     return -1;
   }
 
+  /**
+   * Return the index of the nth non-zero bit.
+   * @param {number} n The number of non-zero bits to advance.
+   * @return {number} The index of the nth non-zero bit.
+   */
   nth(n) {
     let i = this.next(0);
     while (n-- && i >= 0) i = this.next(i + 1);
     return i;
   }
 
+  /**
+   * Negate all bits in this bitset.
+   * Modifies this BitSet in place.
+   * @return {this}
+   */
   not() {
     const bits = this._bits;
     const n = bits.length;
@@ -81,6 +127,11 @@ export default class BitSet {
     return this;
   }
 
+  /**
+   * Return the logical AND of this BitSet and another.
+   * @param {BitSet} bitset The BitSet to combine with.
+   * @return {BitSet} The logical AND as a new BitSet.
+   */
   and(bitset) {
     const a = this._bits;
     const b = bitset._bits;
@@ -95,6 +146,11 @@ export default class BitSet {
     return s;
   }
 
+  /**
+   * Return the logical OR of this BitSet and another.
+   * @param {BitSet} bitset The BitSet to combine with.
+   * @return {BitSet} The logical OR as a new BitSet.
+   */
   or(bitset) {
     const a = this._bits;
     const b = bitset._bits;

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -141,7 +141,7 @@ export default class ColumnTable extends Table {
     const create = rowObjectBuilder(this);
     const n = this.numRows();
 
-    if (this.isOrdered() || this.isFiltered) {
+    if (this.isOrdered() || this.isFiltered()) {
       const indices = this.indices();
       for (let i = 0; i < n; ++i) {
         yield create(indices[i]);

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -18,14 +18,11 @@ export default class ColumnTable extends Table {
 
   /**
    * Create a new ColumnTable from existing input data.
-   * @param {*} values The backing table data values.
+   * @param {object[]|Iterable<object>|object|Map} values The backing table data values.
    *  If array-valued, should be a list of JavaScript objects with
    *  key-value properties for each column value.
    *  If object- or Map-valued, a table with two columns (one for keys,
    *  one for values) will be created.
-   *  If the input adheres to an Apache Arrow table (providing a schema
-   *  property with named fields and a getColumn method), the columns
-   *  exported by that object will be used directly.
    * @param {string[]} [names] The named columns to include.
    * @return {ColumnTable} A new ColumnTable instance.
    */
@@ -33,6 +30,15 @@ export default class ColumnTable extends Table {
     return new ColumnTable(columnsFrom(values, names), names);
   }
 
+  /**
+   * Instantiate a new ColumnTable instance.
+   * @param {object} columns An object mapping column names to values.
+   * @param {string[]} [names] An ordered list of column names.
+   * @param {BitSet} [filter] A filtering BitSet.
+   * @param {GroupBySpec} [group] A groupby specification.
+   * @param {RowComparator} [order] A row comparator function.
+   * @param {Params} [params] An object mapping parameter names to values.
+   */
   constructor(columns, names, filter, group, order, params) {
     mapObject(columns, Column.from, columns);
     names = names || Object.keys(columns);
@@ -40,6 +46,14 @@ export default class ColumnTable extends Table {
     super(names, nrows, columns, filter, group, order, params);
   }
 
+  /**
+   * Create a new table with the same type as this table.
+   * The new table may have different data, filter, grouping, or ordering
+   * based on the values of the optional configuration argument. If a
+   * setting is not specified, it is inherited from the current table.
+   * @param {CreateOptions} [options] Creation options for the new table.
+   * @return {ColumnTable} A newly created table.
+   */
   create({ data, names, filter, groups, order }) {
     const f = filter
       ? (this._filter ? this._filter.and(filter) : filter)
@@ -108,7 +122,7 @@ export default class ColumnTable extends Table {
   /**
    * Returns an array of objects representing table rows.
    * @param {ObjectsOptions} [options] The options for row object generation.
-   * @return {Array} An array of row objects.
+   * @return {object[]} An array of row objects.
    */
   objects(options = {}) {
     const create = rowObjectBuilder(this);
@@ -121,7 +135,7 @@ export default class ColumnTable extends Table {
 
   /**
    * Returns an iterator over objects representing table rows.
-   * @return {Iterator} An iterator over row objects.
+   * @return {Iterator<object>} An iterator over row objects.
    */
   *[Symbol.iterator]() {
     const create = rowObjectBuilder(this);
@@ -145,7 +159,7 @@ export default class ColumnTable extends Table {
    * Instead, the backing data itself is filtered and ordered as needed.
    * @param {number[]} [indices] Ordered row indices to materialize.
    *  If unspecified, all rows passing the table filter are used.
-   * @return {Table} A reified table.
+   * @return {ColumnTable} A reified table.
    */
   reify(indices) {
     const nrows = indices ? indices.length : this.numRows();
@@ -185,7 +199,7 @@ export default class ColumnTable extends Table {
    * Format this table as a comma-separated values (CSV) string. Other
    * delimiters, such as tabs or pipes ('|'), can be specified using
    * the options argument.
-   * @param {CSVFormatOptions} options The formatting options.
+   * @param {CSVFormatOptions} [options] The formatting options.
    * @return {string} A delimited-value format string.
    */
   toCSV(options) {
@@ -194,7 +208,7 @@ export default class ColumnTable extends Table {
 
   /**
    * Format this table as an HTML table string.
-   * @param {HTMLOptions} options The formatting options.
+   * @param {HTMLFormatOptions} [options] The formatting options.
    * @return {string} An HTML table string.
    */
   toHTML(options) {
@@ -203,7 +217,7 @@ export default class ColumnTable extends Table {
 
   /**
    * Format this table as a JavaScript Object Notation (JSON) string.
-   * @param {JSONFormatOptions} options The formatting options.
+   * @param {JSONFormatOptions} [options] The formatting options.
    * @return {string} A JSON string.
    */
   toJSON(options) {
@@ -212,10 +226,50 @@ export default class ColumnTable extends Table {
 
   /**
    * Format this table as a GitHub-Flavored Markdown table string.
-   * @param {MarkdownOptions} options The formatting options.
+   * @param {MarkdownFormatOptions} [options] The formatting options.
    * @return {string} A GitHub-Flavored Markdown table string.
    */
   toMarkdown(options) {
     return toMarkdown(this, options);
   }
 }
+
+/**
+ * Proxy type for BitSet class.
+ * @typedef {import('./table').BitSet} BitSet
+ */
+
+/**
+ * Proxy type for GroupBySpec.
+ * @typedef {import('./table').GroupBySpec} GroupBySpec
+ */
+
+/**
+ * Proxy type for RowComparator.
+ * @typedef {import('./table').RowComparator} RowComparator
+ */
+
+/**
+ * Proxy type for Params.
+ * @typedef {import('./table').Params} Params
+ */
+
+/**
+ * Options for CSV formatting.
+ * @typedef {import('../format/to-csv').CSVFormatOptions} CSVFormatOptions
+ */
+
+/**
+ * Options for HTML formatting.
+ * @typedef {import('../format/to-html').HTMLFormatOptions} HTMLFormatOptions
+ */
+
+/**
+ * Options for JSON formatting.
+ * @typedef {import('../format/to-json').JSONFormatOptions} JSONFormatOptions
+ */
+
+/**
+ * Options for Markdown formatting.
+ * @typedef {import('../format/to-markdown').MarkdownFormatOptions} MarkdownFormatOptions
+ */

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -206,8 +206,9 @@ export default class Table extends Transformable {
 
   /**
    * Print the contents of this table using the console.table() method.
-   * @param {ObjectsOptions} options The options for row object generation,
-   *  determining which rows and columns are printed.
+   * @param {ObjectsOptions|number} options The options for row object
+   *  generation, determining which rows and columns are printed. If
+   *  number-valued, specifies the row limit.
    */
   print(options = {}) {
     if (typeof options === 'number') {

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -8,16 +8,14 @@ import repeat from '../util/repeat';
 export default class Table extends Transformable {
 
   /**
-   * Construct a new Table instance.
-   * @param {string[]} names - An array of column names.
-   * @param {number} nrows - The number of rows.
-   * @param {*} data - The backing data, which can vary by implementation.
-   * @param {BitSet} [filter] - A bit mask for which rows to include.
-   * @param {object} [groups] - Row grouping criteria.
-   * @param {string[]} [groups.names] - Output column names for grouping variables.
-   * @param {function[]} [groups.get] - Accessor functions for grouping variables.
-   * @param {function} [order] - A comparator function for sorting rows.
-   * @param {object} [params] - Parameter values for table expressions.
+   * Instantiate a new Table instance.
+   * @param {string[]} names An ordered list of column names.
+   * @param {number} nrows The number of rows.
+   * @param {TableData} data The backing data, which can vary by implementation.
+   * @param {BitSet} [filter] A bit mask for which rows to include.
+   * @param {GroupBySpec} [groups] A groupby specification for grouping ows.
+   * @param {RowComparator} [order] A comparator function for sorting rows.
+   * @param {Params} [params] Parameter values for table expressions.
    */
   constructor(names, nrows, data, filter, groups, order, params) {
     super(params);
@@ -31,6 +29,18 @@ export default class Table extends Transformable {
   }
 
   /**
+   * Create a new table with the same type as this table.
+   * The new table may have different data, filter, grouping, or ordering
+   * based on the values of the optional configuration argument. If a
+   * setting is not specified, it is inherited from the current table.
+   * @param {CreateOptions} [options] Creation options for the new table.
+   * @return {this} A newly created table.
+   */
+  create(options) { // eslint-disable-line no-unused-vars
+    error('Not implemented');
+  }
+
+  /**
    * Provide an informative object string tag.
    */
   get [Symbol.toStringTag]() {
@@ -41,23 +51,6 @@ export default class Table extends Transformable {
       + (this.isFiltered() ? ` (${this.totalRows()} backing)` : '')
       + (this.isGrouped() ? `, ${this._group.size} groups` : '')
       + (this.isOrdered() ? ', ordered' : '');
-  }
-
-  /**
-   * Create a new table with the same type as this table.
-   * The new table may have different data, filter, grouping, or ordering
-   * based on the values of the optional configuration argument. If a
-   * setting is not specified, it is inherited from the current table.
-   * @param {object} [config] Configuration settings for the new table:
-   *  - data: The data payload to use.
-   *  - names: An ordered list of column names.
-   *  - filter: An additional filter bitset to apply.
-   *  - groups: The groupby specification to use (null for no groups).
-   *  - order: The orderby comparator to use (null for no order).
-   *  - params: Table expression parameters.
-   * @return {Table} A newly created table.
-   */
-  create() {
   }
 
   /**
@@ -86,21 +79,11 @@ export default class Table extends Transformable {
 
   /**
    * Returns the internal table storage data structure.
-   * @return {*} The backing table storage data structure.
+   * @return {TableData} The backing table storage data structure.
    */
   data() {
     return this._data;
   }
-
-  /**
-   * A table groupby specification.
-   * @typedef {object} GroupBySpec
-   * @property {number} size - The number of groups.
-   * @property {string[]} names - Column names for each group.
-   * @property {Function[]} get - Value accessor functions for each group.
-   * @property {number[]} rows - Indices of an example table row for each group.
-   * @property {number[]} keys - Per-row group indices, length is total rows of table.
-   */
 
   /**
    * Returns the groupby specification, if defined.
@@ -112,7 +95,7 @@ export default class Table extends Transformable {
 
   /**
    * Returns the row order comparator function, if specified.
-   * @return {Function} The row order comparator function.
+   * @return {RowComparator} The row order comparator function.
    */
   comparator() {
     return this._order;
@@ -147,7 +130,7 @@ export default class Table extends Transformable {
 
   /**
    * Filter function invoked for each column name.
-   * @callback nameFilter
+   * @callback NameFilter
    * @param {string} name The column name.
    * @param {number} index The column index.
    * @param {string[]} array The array of names.
@@ -156,7 +139,7 @@ export default class Table extends Transformable {
 
   /**
    * The table column names, optionally filtered.
-   * @param {nameFilter} [filter] An optional filter function.
+   * @param {NameFilter} [filter] An optional filter function.
    *  If unspecified, all column names are returned.
    * @return {string[]} An array of matching column names.
    */
@@ -187,7 +170,7 @@ export default class Table extends Transformable {
    * Get the value for the given column and row.
    * @param {string} name The column name.
    * @param {number} row The row index.
-   * @return {*} The table value at (column, row).
+   * @return {TableValue} The table value at (column, row).
    */
   get(name, row) { // eslint-disable-line no-unused-vars
     error('Not implemented');
@@ -198,23 +181,16 @@ export default class Table extends Transformable {
    * function takes a row index as its single argument and returns the
    * corresponding column value.
    * @param {string} name The column name.
-   * @return {Function} The column getter function.
+   * @return {(row: number) => TableValue} The column getter function.
    */
   getter(name) { // eslint-disable-line no-unused-vars
     error('Not implemented');
   }
 
   /**
-   * Options for generating row objects.
-   * @typedef {object} ObjectsOptions
-   * @property {number} [limit=Infinity] The maximum number of objects to create.
-   * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
-   */
-
-  /**
    * Returns an array of objects representing table rows.
    * @param {ObjectsOptions} [options] The options for row object generation.
-   * @return {Array} An array of row objects.
+   * @return {RowObject[]} An array of row objects.
    */
   objects(options) { // eslint-disable-line no-unused-vars
     error('Not implemented');
@@ -222,7 +198,7 @@ export default class Table extends Transformable {
 
   /**
    * Returns an iterator over objects representing table rows.
-   * @return {Iterator} An iterator over row objects.
+   * @return {Iterator<object>} An iterator over row objects.
    */
   [Symbol.iterator]() {
     error('Not implemented');
@@ -324,18 +300,25 @@ export default class Table extends Transformable {
   }
 
   /**
+   * Callback function to cancel a table scan.
+   * @callback ScanStop
+   * @return {void}
+   */
+
+  /**
    * Callback function invoked for each row of a table scan.
-   * @callback scanVisitor
-   * @param {number} row The table row index.
-   * @param {object|Array} data The backing table data store.
-   * @param {Function} stop Function to stop the scan early.
+   * @callback ScanVisitor
+   * @param {number} [row] The table row index.
+   * @param {TableData} [data] The backing table data store.
+   * @param {ScanStop} [stop] Function to stop the scan early.
    *  Callees can invoke this function to prevent future calls.
+   * @return {void}
    */
 
   /**
    * Perform a table scan, visiting each row of the table.
    * If this table is filtered, only rows passing the filter are visited.
-   * @param {scanVisitor} fn Callback invoked for each row of the table.
+   * @param {ScanVisitor} fn Callback invoked for each row of the table.
    * @param {boolean} [order=false] Indicates if the table should be
    *  scanned in the order determined by {@link Table#orderby}. This
    *  argument has no effect if the table is unordered.
@@ -376,10 +359,80 @@ export default class Table extends Transformable {
    * To produce standard aggregate summaries, use {@link rollup}.
    * This method allows the use of custom reducer implementations,
    * for example to produce multiple rows for an aggregate.
-   * @param  {Reducer} reducer The reducer to apply.
+   * @param {Reducer} reducer The reducer to apply.
    * @return {Table} A new table of reducer outputs.
    */
   reduce(reducer) {
     return this.__reduce(this, reducer);
   }
 }
+
+/**
+ * Backing table data.
+ * @typedef {object|Array} TableData
+ */
+
+/**
+ * Table value.
+ * @typedef {*} TableValue
+ */
+
+/**
+ * Table row object.
+ * @typedef {Object.<string, TableValue>} RowObject
+ */
+
+/**
+ * Table expression parameters.
+ * @typedef {import('./transformable').Params} Params
+ */
+
+/**
+ * Proxy type for BitSet class.
+ * @typedef {typeof import('./bit-set')} BitSet
+ */
+
+/**
+ * A table groupby specification.
+ * @typedef {object} GroupBySpec
+ * @property {number} size The number of groups.
+ * @property {string[]} names Column names for each group.
+ * @property {RowExpression[]} get Value accessor functions for each group.
+ * @property {number[]} rows Indices of an example table row for each group.
+ * @property {number[]} keys Per-row group indices, length is total rows of table.
+ */
+
+/**
+ * An expression evaluated over a table row.
+ * @callback RowExpression
+ * @param {number} [row] The table row.
+ * @param {TableData} [data] The backing table data store.
+ * @return {TableValue}
+ */
+
+/**
+ * Comparator function for sorting table rows.
+ * @callback RowComparator
+ * @param {number} rowA The table row index for the first row.
+ * @param {number} rowB The table row index for the second row.
+ * @param {TableData} data The backing table data store.
+ * @return {number} Negative if rowA < rowB, positive if
+ *  rowA > rowB, otherwise zero.
+ */
+
+/**
+ * Options for derived table creation.
+ * @typedef {object} CreateOptions
+ * @property {TableData} [data] The backing column data.
+ * @property {string[]} [names] An ordered list of column names.
+ * @property {BitSet} [filter] An additional filter BitSet to apply.
+ * @property {GroupBySpec} [groups] The groupby specification to use, or null for no groups.
+ * @property {RowComparator} [order] The orderby comparator function to use, or null for no order.
+ */
+
+/**
+ * Options for generating row objects.
+ * @typedef {object} ObjectsOptions
+ * @property {number} [limit=Infinity] The maximum number of objects to create.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
+ */

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -5,6 +5,10 @@ import toArray from '../util/to-array';
  */
 export default class Transformable {
 
+  /**
+   * Instantiate a new Transformable instance.
+   * @param {Params} [params] The parameter values.
+   */
   constructor(params) {
     if (params) this._params = params;
   }
@@ -15,8 +19,8 @@ export default class Transformable {
    * as an object. Otherwise, adds the provided parameters to this
    * table's parameter set and returns the table. Any prior parameters
    * with names matching the input parameters are overridden.
-   * @param {object} values The parameter values.
-   * @return {this|object} The current parameters values (if called with
+   * @param {Params} [values] The parameter values.
+   * @return {this|Params} The current parameters values (if called with
    *  no arguments) or this table.
    */
   params(values) {
@@ -161,7 +165,7 @@ export default class Transformable {
    * Rollup a table to produce an aggregate summary.
    * Often used in conjunction with {@link Transformable#groupby}.
    * To produce counts only, {@link Transformable#count} is a shortcut.
-   * @param {ExprObject} values Object of name-value pairs defining aggregate
+   * @param {ExprObject} [values] Object of name-value pairs defining aggregate
    *  output columns. The input object should have output column names for
    *  keys and table expressions for values. The expressions must be valid
    *  aggregate expressions: window functions are not allowed and column
@@ -373,7 +377,7 @@ export default class Transformable {
    * Lookup is similar to {@link Transformable#join_left}, but with a simpler
    * syntax and the added constraint of allowing at most one match only.
    * @param {TableRef} other The secondary table to look up values from.
-   * @param {JoinKeys} on Lookup keys (column name strings or table
+   * @param {JoinKeys} [on] Lookup keys (column name strings or table
    *  expressions) for this table and the secondary table, respectively.
    * @param {...ExprList} values The column values to add from the
    *  secondary table. Can be column name strings or objects with column
@@ -686,18 +690,23 @@ export default class Transformable {
 // -- Parameter Types -------------------------------------------------------
 
 /**
+ * Table expression parameters.
+ * @typedef {Object.<string, *>} Params
+ */
+
+/**
  * A reference to a column by string name or integer index.
  * @typedef {string|number} ColumnRef
  */
 
 /**
  * A function defined over a table row.
- * @typedef {(d?: object, $?: object) => any} TableExpr
+ * @typedef {(d?: object, $?: Params) => any} TableExpr
  */
 
 /**
  * A function defined over rows from two tables.
- * @typedef {(a?: object, b?: object, $?: object) => any} TableExpr2
+ * @typedef {(a?: object, b?: object, $?: Params) => any} TableExpr2
  */
 
 /**
@@ -707,7 +716,7 @@ export default class Transformable {
 
 /**
  * A selection helper function.
- * @typedef {Function} SelectHelper
+ * @typedef {(table: any) => string[]} SelectHelper
  */
 
 /**


### PR DESCRIPTION
- Update JSDoc comments and improve generated TypeScript typings.
- Update [Table](https://uwdata.github.io/arquero/api/table) API docs.
- Fix table iterator filter check bug.

Fix #72.