### PR TITLE
Revise CSV auto type inference.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -33,7 +33,7 @@ JavaScript objects have specific key ordering rules: keys are enumerated in the 
 
 This method can be used to create a new table that binds together columns from multiple input sources, so long as all provided columns have the same length. See the examples below for more.
 
-* *columns*: An object providing a named set of column arrays. Object keys are column names; the enumeration order of the keys determines the column indices if the *names* argument is not provided. Object values must be arrays (or array-like values) of identical length.
+* *columns*: An object or Map providing a named set of column arrays. Object keys are column names; the enumeration order of the keys determines the column indices if the *names* argument is not provided. Object values must be arrays (or array-like values) of identical length.
 * *names*: An array of column names, specifying the index order of columns in the table.
 
 *Examples*
@@ -119,9 +119,10 @@ Parse a comma-separated values (CSV) *text* string into a <a href="table">table<
 
 * *text*: A string in a delimited-value format.
 * *options*: A CSV format options object:
-  * *delimiter*: The delimiter string between column values.
+  * *delimiter*: A single-character delimiter string between column values.
   * *header*: Boolean flag (default `true`) to specify the presence of a  header row. If `true`, indicates the CSV contains a header row with column names. If `false`, indicates the CSV does not contain a header row and the columns are given the names `'col1'`, `'col2'`, and so on.
   * *autoType*: Boolean flag (default `true`) for automatic type inference.
+  * *autoMax*: Maximum number of initial rows (default `1000`) to use for type inference.
   * *parse*: Object of column parsing options. The object keys should be column names. The object values should be parsing functions to invoke to transform values upon input.
 
 *Examples*

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "prebuild": "rimraf dist && mkdir dist",
     "build": "rollup -c",
     "postbuild": "tsc",
+    "preperf": "yarn build",
+    "perf": "TZ=America/Los_Angeles tape 'perf/**/*-perf.js'",
     "lint": "yarn eslint src test --ext .js",
     "test": "TZ=America/Los_Angeles tape 'test/**/*-test.js' --require esm",
     "prepublishOnly": "yarn test && yarn lint && yarn build"

--- a/perf/csv-perf.js
+++ b/perf/csv-perf.js
@@ -1,0 +1,119 @@
+const tape = require('tape');
+const { fromCSV, table } = require('..');
+
+function rint(min, max) {
+  let delta = min;
+  if (max === undefined) {
+    min = 0;
+  } else {
+    delta = max - min;
+  }
+  return (min + delta * Math.random()) | 0;
+}
+
+function ints(n, min, max, nullf) {
+  const data = [];
+  for (let i = 0; i < n; ++i) {
+    const v = nullf && Math.random() < nullf ? null : rint(min, max);
+    data.push(v);
+  }
+  return data;
+}
+
+function floats(n, min, max, nullf) {
+  const data = [];
+  const delta = max - min;
+  for (let i = 0; i < n; ++i) {
+    const v = nullf && Math.random() < nullf
+      ? null
+      : (min + delta * Math.random());
+    data.push(v);
+  }
+  return data;
+}
+
+function dates(n, nullf) {
+  const data = [];
+  for (let i = 0; i < n; ++i) {
+    const v = nullf && Math.random() < nullf
+      ? null
+      : new Date(1970 + rint(0, 41), 0, rint(1, 366));
+    data.push(v);
+  }
+  return data;
+}
+
+function sample(n, values, nullf) {
+  const data = [];
+  for (let i = 0; i < n; ++i) {
+    const v = nullf && Math.random() < nullf
+      ? null
+      : values[~~(values.length * Math.random())];
+    data.push(v);
+  }
+  return data;
+}
+
+function strings(n) {
+  const c = 'bcdfghjlmpqrstvwxyz';
+  const v = 'aeiou';
+  const cn = c.length;
+  const vn = v.length;
+  const data = [];
+  const map = {};
+  while (data.length < n) {
+    const s = c[rint(cn)] + v[rint(vn)] + c[rint(cn)] + c[rint(cn)];
+    if (!map[s]) {
+      data.push(s);
+      map[s] = 1;
+    }
+  }
+  return data;
+}
+
+function bools(n, nullf) {
+  const data = [];
+  for (let i = 0; i < n; ++i) {
+    const v = nullf && Math.random() < nullf ? null : (Math.random() < 0.5);
+    data.push(v);
+  }
+  return data;
+}
+
+function toCSV(...values) {
+  const cols = values.map((v, i) => [`col${i}`, v]);
+  return table(cols).toCSV();
+}
+
+function parse(csv, opt) {
+  const t0 = Date.now();
+  const tt = (fromCSV(csv, opt), Date.now() - t0);
+  return tt;
+}
+
+function run(N, nulls, msg) {
+  const opt = {
+    parse: [0,1,2,3,4].reduce((p, i) => (p[`col${i}`] = x => x, p), {})
+  };
+  const bv = bools(N, nulls);
+  const iv = ints(N, -10000, 10000, nulls);
+  const fv = floats(N, -10000, 10000, nulls);
+  const dv = dates(N, nulls);
+  const sv = sample(N, strings(100), nulls);
+  const av = [bv, iv, fv, dv, sv];
+
+  tape(`parse csv: ${msg}`, t => {
+    console.table([ // eslint-disable-line
+      { type: 'boolean', raw: parse(toCSV(bv), opt), typed: parse(toCSV(bv)) },
+      { type: 'integer', raw: parse(toCSV(iv), opt), typed: parse(toCSV(iv)) },
+      { type: 'float',   raw: parse(toCSV(fv), opt), typed: parse(toCSV(fv)) },
+      { type: 'date',    raw: parse(toCSV(dv), opt), typed: parse(toCSV(dv)) },
+      { type: 'string',  raw: parse(toCSV(sv), opt), typed: parse(toCSV(sv)) },
+      { type: 'all',     raw: parse(toCSV(...av), opt), typed: parse(toCSV(...av)) }
+    ]);
+    t.end();
+  });
+}
+
+run(1e5, 0, '100k values');
+run(1e5, 0.05, '100k values, 5% nulls');

--- a/src/engine/impute.js
+++ b/src/engine/impute.js
@@ -2,7 +2,7 @@ import { aggregateGet } from './reduce/util';
 import columnSet from '../table/column-set';
 import isValid from '../util/is-valid';
 import keyFunction from '../util/key-function';
-import unroll2 from '../util/unroll2';
+import unroll from '../util/unroll';
 
 export default function(table, values, keys, arrays) {
   const write = keys && keys.length;
@@ -58,9 +58,10 @@ function expand(table, keys, values) {
 
   // enumerate expanded value sets and augment output table
   const keyEnum = keyFunction(keyGet.map((k, i) => a => a[i]));
-  const set = unroll2(
-    out, names.map(name => keyNames.indexOf(name)), 'v',
-    '{' + out.map((_, i) => `_${i}.push(v[$${i}]);`).join('') + '}'
+  const set = unroll(
+    'v',
+    '{' + out.map((_, i) => `_${i}.push(v[$${i}]);`).join('') + '}',
+    out, names.map(name => keyNames.indexOf(name))
   );
 
   if (groups) {

--- a/src/engine/join.js
+++ b/src/engine/join.js
@@ -1,12 +1,15 @@
 import columnSet from '../table/column-set';
 import concat from '../util/concat';
 import isArray from '../util/is-array';
-import unroll from '../util/unroll2';
+import unroll from '../util/unroll';
 
 function emitter(columns, getters) {
   const args = ['i', 'a', 'j', 'b'];
-  return unroll(columns, getters, args,
-    '{' + concat(columns, (_, i) => `_${i}.push($${i}(${args}));`) + '}');
+  return unroll(
+    args,
+    '{' + concat(columns, (_, i) => `_${i}.push($${i}(${args}));`) + '}',
+    columns, getters
+  );
 }
 
 export default function(tableL, tableR, predicate, { names, exprs }, options = {}) {

--- a/src/engine/reduce/field-reducer.js
+++ b/src/engine/reduce/field-reducer.js
@@ -7,8 +7,9 @@ import unroll from '../../util/unroll';
 import ValueList from '../../util/value-list';
 
 const update = (ops, args, fn) => unroll(
-  ops, args,
-  '{' + concat(ops, (_, i) => `_${i}.${fn}(${args});`) + '}'
+  args,
+  '{' + concat(ops, (_, i) => `_${i}.${fn}(${args});`) + '}',
+  ops
 );
 
 export default function(oplist, stream) {

--- a/src/engine/window/window-state.js
+++ b/src/engine/window/window-state.js
@@ -13,8 +13,9 @@ export default function(data, frame, adjust, ops, aggrs) {
 
   const evaluate = ops.length
     ? unroll(
-      ops, ['w', 'r'],
-        '{' + concat(ops, (_, i) => `r[_${i}.name]=_${i}.value(w,_${i}.get);`) + '}'
+        ['w', 'r'],
+        '{' + concat(ops, (_, i) => `r[_${i}.name]=_${i}.value(w,_${i}.get);`) + '}',
+        ops
       )
     : () => {};
 

--- a/src/engine/window/window.js
+++ b/src/engine/window/window.js
@@ -1,7 +1,7 @@
 import { reducers } from '../reduce/util';
 import { getWindow, isAggregate } from '../../op';
 import concat from '../../util/concat';
-import unroll2 from '../../util/unroll2';
+import unroll from '../../util/unroll';
 import windowState from './window-state';
 
 const frameValue = op =>
@@ -23,10 +23,10 @@ export function window(table, output, exprs, results = [], ops) {
   const states = windowStates(ops, input);
   const nstate = states.length;
 
-  const write = unroll2(
-    output, exprs,
-    ['r', 'input', 'result'],
-    '{' + concat(output, (_, i) => `_${i}[r] = $${i}(r, input, result);`) + '}'
+  const write = unroll(
+    ['r', 'd', 'res'],
+    '{' + concat(output, (_, i) => `_${i}[r] = $${i}(r, d, res);`) + '}',
+    output, exprs
   );
 
   // scan each ordered partition

--- a/src/format/from-arrow.js
+++ b/src/format/from-arrow.js
@@ -2,7 +2,6 @@ import ColumnTable from '../table/column-table';
 import error from '../util/error';
 import toString from '../util/to-string';
 import unroll from '../util/unroll';
-import unroll2 from '../util/unroll2';
 import resolve, { all } from '../verbs/expr/selection';
 
 // Hardwire Arrow type ids to avoid explicit dependency
@@ -93,11 +92,11 @@ function collectFiltered(input, names, cols, count) {
     idx => collect(++row, idx),
     () => {
       ++batch;
-      collect = unroll2(
-        out,
-        cols.map((col, i) => extractFrom(col.chunks[batch], lut[i])),
+      collect = unroll(
         ['row', 'idx'],
-        '{' + out.map((_, i) => `_${i}[row]=$${i}(idx)`).join(';') + ';}'
+        '{' + out.map((_, i) => `_${i}[row]=$${i}(idx)`).join(';') + ';}',
+        out,
+        cols.map((col, i) => extractFrom(col.chunks[batch], lut[i]))
       );
     }
   );
@@ -171,8 +170,9 @@ function structExtractor(vector) {
   const names = vector.type.children.map(field => field.name);
   const values = names.map((_, i) => arrayExtractor(vector.getChildAt(i)));
   return unroll(
-    values, 'i',
-    '({' + names.map((_, d) => `${toString(_)}:_${d}[i]`) + '})'
+    'i',
+    '({' + names.map((_, d) => `${toString(_)}:_${d}[i]`) + '})',
+    values
   );
 }
 

--- a/src/format/from-csv.js
+++ b/src/format/from-csv.js
@@ -1,20 +1,24 @@
 import ColumnTable from '../table/column-table';
-import autoType from '../util/auto-type';
 import isFunction from '../util/is-function';
-import parse from '../util/parse-dsv';
+import identity from '../util/identity';
+import parseDSV from '../util/parse-dsv';
+import valueParser from '../util/parse-values';
 import repeat from '../util/repeat';
+import error from '../util/error';
 
-const DEFAULT_COLUMN_NAME = 'col';
+const DEFAULT_NAME = 'col';
 
 /**
  * Options for CSV parsing.
  * @typedef {object} CSVParseOptions
- * @property {string} [delimiter=','] The delimiter between values.
- * @property {boolean} [autoType=true] Flag controlling automatic type inference.
+ * @property {string} [delimiter=','] Single-character delimiter between values.
  * @property {boolean} [header=true] Flag to specify presence of header row.
  *  If true, assumes the CSV contains a header row with column names.
  *  If false, indicates the CSV does not contain a header row, and the
  *  columns are given the names 'col1', 'col2', and so on.
+ * @property {boolean} [autoType=true] Flag for automatic type inference.
+ * @property {number} [autoMax=1000] Maximum number of initial values to use
+ *  for type inference.
  * @property {Object.<string, (value: string) => any>} [parse] Object of
  *  column parsing options. The object keys should be column names. The object
  *  values should be parsing functions that transform values upon input.
@@ -33,35 +37,55 @@ const DEFAULT_COLUMN_NAME = 'col';
  * @param {ColumnTable} table A new table containing the parsed values.
  */
 export default function(text, options = {}) {
-  const delimiter = options.delimiter == null ? ',' : options.delimiter;
-  const delim = (delimiter + '').charCodeAt(0);
-  const defaultParser = options.autoType !== false ? autoType : d => d;
+  const delim = options.delimiter == null ? ',' : options.delimiter;
   const header = options.header !== false;
-  let names, values, parsers;
+  const automax = +options.autoMax || 1000;
 
-  parse(text, delim, (array, index) => {
-    if (index === 0) {
-      const n = array.length;
-      values = repeat(n, () => []);
-      parsers = Array(n).fill(defaultParser);
+  if (delim.length > 1) error('CSV delimiter should be a single character.');
+  const rows = parseDSV(text, (delim + '').charCodeAt(0));
+  let row = rows.next() || [];
 
-      if (header) {
-        const p = options.parse || {};
-        (names = array)
-          .forEach((_, i) => isFunction(p[_]) ? (parsers[i] = p[_]) : 0);
-        return;
-      } else {
-        names = repeat(n, i => `${DEFAULT_COLUMN_NAME}${i + 1}`);
-      }
-    }
+  const n = row.length;
+  const values = repeat(n, () => []);
+  const names = header ? row : repeat(n, i => `${DEFAULT_NAME}${i + 1}`);
 
-    const n = names.length;
+  // read in initial rows to guess types
+  let idx = 0;
+  row = header ? rows.next() : row;
+  for (; idx < automax && row; ++idx, row = rows.next()) {
     for (let i = 0; i < n; ++i) {
-      values[i].push(parsers[i](array[i]));
+      values[i].push(row[i] === '' ? null : row[i]);
+    }
+  }
+
+  // initialize parsers
+  const parsers = options.autoType === false
+    ? Array(n).fill(identity)
+    : getParsers(names, values, options.parse);
+
+  // apply parsers
+  parsers.forEach((parse, i) => {
+    if (parse === identity) return;
+    const v = values[i];
+    for (let r = 0; r < idx; ++r) {
+      if (v[r] != null) v[r] = parse(v[r]);
     }
   });
+
+  // parse remainder of file
+  for (; row; row = rows.next()) {
+    for (let i = 0; i < n; ++i) {
+      values[i].push(row[i] === '' ? null : parsers[i](row[i]));
+    }
+  }
 
   const columns = {};
   names.forEach((name, i) => columns[name] = values[i]);
   return new ColumnTable(columns, names);
+}
+
+function getParsers(names, values, opt = {}) {
+  return names.map(
+    (name, i) => isFunction(opt[name]) ? opt[name] : valueParser(values[i])
+  );
 }

--- a/src/util/identity.js
+++ b/src/util/identity.js
@@ -1,0 +1,1 @@
+export default x => x;

--- a/src/util/is-iso-date-string.js
+++ b/src/util/is-iso-date-string.js
@@ -1,0 +1,5 @@
+const iso_re = /^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/;
+
+export default function(value) {
+  return value.match(iso_re);
+}

--- a/src/util/parse-dsv.js
+++ b/src/util/parse-dsv.js
@@ -27,10 +27,9 @@ const RETURN = 13;
 // ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-export default function(text, delimCode, callback) {
+export default function(text, delimCode) {
   let N = text.length,
       I = 0, // current character index
-      n = 0, // current line number
       t, // current token
       eof = N <= 0, // current token followed by EOF?
       eol = false; // current token followed by EOL?
@@ -66,9 +65,13 @@ export default function(text, delimCode, callback) {
     return eof = true, text.slice(j, N);
   }
 
-  while ((t = token()) !== EOF) {
-    const row = [];
-    while (t !== EOL && t !== EOF) row.push(t), t = token();
-    if (callback(row, n++) == null) continue;
-  }
+  return {
+    next() {
+      if ((t = token()) !== EOF) {
+        const row = [];
+        while (t !== EOL && t !== EOF) row.push(t), t = token();
+        return row;
+      }
+    }
+  };
 }

--- a/src/util/parse-iso-date.js
+++ b/src/util/parse-iso-date.js
@@ -1,15 +1,5 @@
-const iso_re = /^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/;
-
-const fix_tz = new Date('2019-01-01T00:00').getHours()
-            || new Date('2019-07-01T00:00').getHours();
+import isISODateString from './is-iso-date-string';
 
 export default function(value, parse = Date.parse) {
-  const m = value.match(iso_re);
-  if (m) {
-    if (fix_tz && !!m[4] && !m[7]) {
-      value = value.replace(/-/g, '/').replace(/T/, ' ');
-    }
-    value = parse(value);
-  }
-  return value;
+  return isISODateString(value) ? parse(value) : value;
 }

--- a/src/util/parse-values.js
+++ b/src/util/parse-values.js
@@ -1,0 +1,39 @@
+import identity from './identity';
+import isISODateString from './is-iso-date-string';
+
+const TYPES = [
+  [ // boolean
+    v => (v === 'true') || (v === 'false'),
+    v => v === 'false' ? false : true
+  ],
+  [ // number
+    v => v === 'NaN' || (v = +v) === v,
+    v => +v
+  ],
+  [ // iso date
+    isISODateString,
+    v => new Date(Date.parse(v))
+  ]
+];
+
+export default function(values) {
+  const n = TYPES.length;
+  for (let i = 0; i < n; ++i) {
+    const [test, parser] = TYPES[i];
+    if (check(values, test)) {
+      return parser;
+    }
+  }
+  return identity;
+}
+
+function check(values, test) {
+  const n = values.length;
+  for (let i = 0; i < n; ++i) {
+    const v = values[i];
+    if (v != null && !test(v)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/util/row-object-builder.js
+++ b/src/util/row-object-builder.js
@@ -3,8 +3,8 @@ import unroll from './unroll';
 export default function(table, names) {
   names = names || table.columnNames();
   return unroll(
-    names.map(name => table.column(name)),
     'row',
-    '({' + names.map((_, i) => `${JSON.stringify(_)}:_${i}.get(row)`) + '})'
+    '({' + names.map((_, i) => `${JSON.stringify(_)}:_${i}.get(row)`) + '})',
+    names.map(name => table.column(name))
   );
 }

--- a/src/util/unroll.js
+++ b/src/util/unroll.js
@@ -1,7 +1,11 @@
-export default function(list, args, code) {
-  return Function('_',
-    '"use strict"; const '
-    + list.map((_, i) => `_${i} = _[${i}]`).join(', ')
+export default function(args, code, ...lists) {
+  const v = ['_', '$'];
+  const a = v.slice(0, lists.length);
+  a.push('"use strict"; const '
+    + lists
+        .map((l, j) => l.map((_, i) => `${v[j]}${i} = ${v[j]}[${i}]`).join(', '))
+        .join(', ')
     + `; return (${args}) => ${code};`
-  )(list);
+  );
+  return Function(...a)(...lists);
 }

--- a/src/util/unroll2.js
+++ b/src/util/unroll2.js
@@ -1,9 +1,0 @@
-export default function(list1, list2, args, code) {
-  return Function('_', '$',
-    '"use strict"; const '
-    + list1.map((_, i) => `_${i} = _[${i}]`).join(', ')
-    + '; const '
-    + list2.map((_, i) => `$${i} = $[${i}]`).join(', ')
-    + `; return (${args}) => ${code};`
-  )(list1, list2);
-}

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -26,7 +26,7 @@ import __unorder from '../engine/unorder';
 
 import { count } from '../op/op-api';
 import ColumnTable from '../table/column-table';
-import mapObject from '../util/map-object';
+import entries from '../util/entries';
 
 const __count = (table, options) => __rollup(table, {
   [options && options.as || 'count']: count()
@@ -83,12 +83,11 @@ export {
 
 /**
  * Create a new table for a set of named columns.
- * @param {object} columns
- *  The set of named column arrays.
- *  Object keys are the column names.
+ * @param {object|Map} columns
+ *  The set of named column arrays. Keys are column names.
  *  The enumeration order of the keys determines the column indices,
  *  unless the names parameter is specified.
- *  Object values must be arrays (or array-like values) of identical length.
+ *  Values must be arrays (or array-like values) of identical length.
  * @param {string[]} [names] Ordered list of column names. If specified,
  *  this array determines the column indices. If not specified, the
  *  key enumeration order of the columns object is used.
@@ -96,7 +95,11 @@ export {
  * @example table({ colA: ['a', 'b', 'c'], colB: [3, 4, 5] })
  */
 export function table(columns, names) {
-  return new ColumnTable(mapObject(columns, x => x), names);
+  const cols = entries(columns);
+  return new ColumnTable(
+    cols.reduce((obj, [k, v]) => (obj[k] = v, obj), {}),
+    names || cols.map(c => c[0])
+  );
 }
 
 /**

--- a/test/format/csv-test.js
+++ b/test/format/csv-test.js
@@ -83,6 +83,23 @@ tape('fromCSV parses delimited text', t => {
   t.end();
 });
 
+tape('fromCSV infers types', t => {
+  function check(msg, values, test) {
+    const d = fromCSV('col\n' + values.join('\n')).column('col').data;
+    t.ok(d.every(v => v == null || test(v)), msg);
+  }
+
+  check('boolean', [true, false, '', true], v => typeof v === 'boolean');
+  check('number', [1, Math.PI, '', 'NaN'], v => typeof v === 'number');
+  check('string', ['a', 1, '', 'c'], v => typeof v === 'string');
+  check('date', [
+    new Date().toISOString(), '',
+    new Date(2000, 0, 1).toISOString(),
+    new Date(1979, 3, 14, 3, 45).toISOString()
+  ], v => v instanceof Date);
+  t.end();
+});
+
 tape('fromCSV parses delimited text with delimiter', t => {
   const table = fromCSV(tabText.join('\n'), { delimiter: '\t' });
   t.equal(table.numRows(), 3, 'num rows');
@@ -91,7 +108,7 @@ tape('fromCSV parses delimited text with delimiter', t => {
   t.end();
 });
 
-tape('fromCSV parses delimited text with parse option', t => {
+tape('fromCSV parses delimited text with header option', t => {
   const table = fromCSV(text.slice(1).join('\n'), { header: false });
   const cols = data();
   const d = {
@@ -105,7 +122,7 @@ tape('fromCSV parses delimited text with parse option', t => {
   t.end();
 });
 
-tape('fromCSV parses delimited text with header option', t => {
+tape('fromCSV parses delimited text with parse option', t => {
   const table = fromCSV(text.join('\n'), { parse: { str: d => d + d } });
   const d = { ...data(), str: ['aa', 'bb', 'cc'] };
   tableEqual(t, table, d, 'csv parsed data with custom parse');


### PR DESCRIPTION
- Update `fromCSV()` parsing to ensure consistent types across column values.
- Add `autoMax` option to `fromCSV()` to control how many initial rows are used for type inference.
- Update `table()` constructor to accept `Map` objects and `[[key, value], ...]` entry arrays as input.
- Add internal performance benchmark scripts.
- Refactor internal loop unrolling utility.