### PR TITLE
Make Column iterable.

### DIFF
--- a/src/table/column.js
+++ b/src/table/column.js
@@ -31,6 +31,14 @@ export default class Column {
   get(row) {
     return this.data[row];
   }
+
+  /**
+   * Returns an iterator over the column values.
+   * @return {Iterator<object>} An iterator over column values.
+   */
+  [Symbol.iterator]() {
+    return this.data[Symbol.iterator]();
+  }
 }
 
 /**


### PR DESCRIPTION
This exposes a [Symbol.iterator] method on Column simply by passing through to the underlying data. This means that you can iterate over column values slightly more succinctly (no `.data` required), for example:

```js
for (const value of table.column("foo")) {
  console.log(value);
}
```

Or to make a copy of a column:

```js
const foo = Array.from(table.column("foo"));
```