### PR TITLE
Add frac() helper function.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,7 +8,7 @@ title: Arquero API Reference
 * [Table Constructors](#table-constructors)
   * [table](#table), [from](#from), [fromArrow](#fromArrow), [fromCSV](#fromCSV), [fromJSON](#fromJSON)
 * [Expression Helpers](#expression-helpers)
-  * [op](#op), [bin](#bin), [desc](#desc), [rolling](#rolling), [seed](#seed)
+  * [op](#op), [bin](#bin), [desc](#desc), [frac](#frac), [rolling](#rolling), [seed](#seed)
 * [Selection Helpers](#selection-helpers)
   * [all](#all), [not](#not), [range](#range)
   * [matches](#matches), [startswith](#startswith), [endswith](#endswith)
@@ -257,6 +257,19 @@ aq.desc('colA')
 // sort colA in descending order of lower case values
 aq.desc(d => op.lower(d.colA))
 ```
+
+<hr/><a id="frac" href="#frac">#</a>
+<em>aq</em>.<b>frac</b>(<i>fraction</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/expr/frac.js)
+
+Generate a table expression that computes the number of rows corresponding to a given fraction for each group. The resulting string can be used as part of the input to the [sample](verbs/#sample) verb.
+
+* *fraction*: The fractional value.
+
+ *Examples*
+
+```js
+ aq.frac(0.5)
+ ```
 
 <a id="rolling" href="#rolling">#</a>
 <em>aq</em>.<b>rolling</b>(<i>expr</i>[, <i>frame</i>, <i>includePeers</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/expr/rolling.js)

--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -190,7 +190,12 @@ table.sample(100, { replace: true })
 
 ```js
 // stratified sampling with dynamic sample size
-table.groupby('colA').sample(() => op.floor(0.5 * op.count()))
+table.groupby('colA').sample(aq.frac(0.5))
+```
+
+```js
+// sample twice the number of records in each group, with replacement
+table.groupby('colA').sample(aq.frac(2), { replace: true })
 ```
 
 <hr/><a id="select" href="#select">#</a>

--- a/src/verbs/expr/frac.js
+++ b/src/verbs/expr/frac.js
@@ -1,0 +1,11 @@
+/**
+ * Generate a table expression that computes the number of rows
+ * corresponding to a given fraction for each group. The resulting
+ * string can be used as part of the input to the sample verb.
+ * @param {number} fraction The fractional value.
+ * @return {string} A table expression string for computing row counts.
+ * @example frac(0.5)
+ */
+export default function(fraction) {
+  return `() => op.round(${+fraction} * op.count())`;
+}

--- a/src/verbs/index.js
+++ b/src/verbs/index.js
@@ -76,6 +76,7 @@ export { default as op } from '../op/op-api';
 export { default as bin } from './expr/bin';
 export { default as desc } from './expr/desc';
 export { default as field } from './expr/field';
+export { default as frac } from './expr/frac';
 export { default as rolling } from './expr/rolling';
 export {
   all, endswith, matches, not, range, startswith

--- a/test/verbs/sample-test.js
+++ b/test/verbs/sample-test.js
@@ -1,5 +1,5 @@
 import tape from 'tape';
-import { op, table } from '../../src/verbs';
+import { frac, table } from '../../src/verbs';
 
 function check(t, table, replace, prefix = '') {
   prefix = `${prefix}sample ${replace ? 'replace ' : ''}rows`;
@@ -129,7 +129,7 @@ tape('sample supports dynamic sample size', t => {
     b: [2, 4, 6, 8]
   };
 
-  const ft = table(cols).sample(() => 0.5 * op.count());
+  const ft = table(cols).sample(frac(0.5));
 
   t.equal(ft.numRows(), 2, 'num rows');
   t.equal(ft.numCols(), 2, 'num cols');


### PR DESCRIPTION
- Add `frac()` helper function to generate an expression for per-group row counts. Useful as an input to the sample verb.

Closes #79.