### PR TITLE
Add slice verb.

### DIFF
--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -7,7 +7,7 @@ title: Verbs \| Arquero API Reference
 
 * [Core Verbs](#verbs)
   * [derive](#derive)
-  * [filter](#filter)
+  * [filter](#filter), [slice](#slice)
   * [groupby](#groupby), [ungroup](#ungroup)
   * [orderby](#orderby), [unorder](#unorder)
   * [rollup](#rollup), [count](#count)
@@ -62,6 +62,26 @@ Filter a table to a subset of rows based on the input criteria. The resulting ta
 
 ```js
 table.filter(d => op.abs(d.value) < 5)
+```
+
+<hr/><a id="slice" href="#slice">#</a>
+<em>table</em>.<b>slice</b>([<i>start</i>, <i>end</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
+
+Extract rows with indices from *start* to *end* (*end* not included), where *start* and *end* represent per-group ordered row numbers in the table. The table row indices are determined by the current [orderby](#orderby) settings. The *start* and *end* arguments are applied separately to each group, as determined by [groupby](#groupby).
+
+* *start*: Zero-based index at which to start extraction. A negative index indicates an offset from the end of the group. If start is undefined, slice starts from the index 0.
+* *end*: Zero-based index before which to end extraction. A negative index indicates an offset from the end of the group. If end is omitted, slice extracts through the end of the group.
+
+*Examples*
+
+```js
+// slice the table to include all rows except for the first and last
+table.slice(1, -1)
+```
+
+```js
+// extract (up to) the first two rows of each group
+table.groupby('colA').slice(0, 2)
 ```
 
 <hr/><a id="groupby" href="#groupby">#</a>

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -356,6 +356,30 @@ export default class Table extends Transformable {
   }
 
   /**
+   * Extract rows with indices from start to end (end not included), where
+   * start and end represent per-group ordered row numbers in the table.
+   * @param {number} [start] Zero-based index at which to start extraction.
+   *  A negative index indicates an offset from the end of the group.
+   *  If start is undefined, slice starts from the index 0.
+   * @param {number} [end] Zero-based index before which to end extraction.
+   *  A negative index indicates an offset from the end of the group.
+   *  If end is omitted, slice extracts through the end of the group.
+   * @return {this} A new table with sliced rows.
+   * @example table.slice(1, -1)
+   */
+  slice(start = 0, end = Infinity) {
+    if (this.isGrouped()) return super.slice(start, end);
+
+    // if not grouped, scan table directly
+    const idx = [];
+    const nrows = this.numRows();
+    start = Math.max(0, start + (start < 0 ? nrows : 0));
+    end = Math.min(nrows, Math.max(0, end + (end < 0 ? nrows : 0)));
+    this.scan(row => idx.push(row), true, end - start, start);
+    return this.reify(idx);
+  }
+
+  /**
    * Reduce a table, processing all rows to produce a new table.
    * To produce standard aggregate summaries, use {@link rollup}.
    * This method allows the use of custom reducer implementations,

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -1,4 +1,5 @@
 import toArray from '../util/to-array';
+import slice from '../verbs/expr/slice';
 
 /**
  * Abstract base class for transforming data.
@@ -93,6 +94,22 @@ export default class Transformable {
    */
   filter(criteria) {
     return this.__filter(this, criteria);
+  }
+
+  /**
+   * Extract rows with indices from start to end (end not included), where
+   * start and end represent per-group ordered row numbers in the table.
+   * @param {number} [start] Zero-based index at which to start extraction.
+   *  A negative index indicates an offset from the end of the group.
+   *  If start is undefined, slice starts from the index 0.
+   * @param {number} [end] Zero-based index before which to end extraction.
+   *  A negative index indicates an offset from the end of the group.
+   *  If end is omitted, slice extracts through the end of the group.
+   * @return {this} A new table with sliced rows.
+   * @example table.slice(1, -1)
+   */
+  slice(start, end) {
+    return this.__filter(this, slice(start, end)).reify();
   }
 
   /**

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -109,7 +109,7 @@ export default class Transformable {
    * @example table.slice(1, -1)
    */
   slice(start, end) {
-    return this.__filter(this, slice(start, end)).reify();
+    return this.filter(slice(start, end)).reify();
   }
 
   /**

--- a/src/verbs/expr/slice.js
+++ b/src/verbs/expr/slice.js
@@ -1,0 +1,21 @@
+/**
+ * Generate a table expression that filters a table based on ordered row
+ * indices from start to end (end not included), where start and end
+ * represent per-group ordered row numbers in the table. The resulting
+ * string can be used as the input to the filter verb.
+ * @param {number} [start] Zero-based index at which to start extraction.
+ *  A negative index indicates an offset from the end of the group.
+ *  If start is undefined, slice starts from the index 0.
+ * @param {number} [end] Zero-based index before which to end extraction.
+ *  A negative index indicates an offset from the end of the group.
+ *  If end is omitted, slice extracts through the end of the group.
+ * @return {string} A table expression string for slicing values.
+ * @example slice(1, -1)
+ */
+export default function(start = 0, end = Infinity) {
+  return `${prep(start)} < row_number() && row_number() <= ${prep(end)}`;
+}
+
+function prep(index) {
+  return index < 0 ? `count() + ${index}` : index;
+}

--- a/src/verbs/filter.js
+++ b/src/verbs/filter.js
@@ -3,11 +3,11 @@ import _filter from '../engine/filter';
 import parse from '../expression/parse';
 
 export default function(table, criteria) {
-  const test = parse({ test: criteria }, { table });
+  const test = parse({ p: criteria }, { table });
   let predicate = test.exprs[0];
   if (test.ops.length) {
-    const bv = _derive(table, test, { drop: true }).column('test');
-    predicate = row => bv.get(row);
+    const { data } = _derive(table, test, { drop: true }).column('p');
+    predicate = row => data[row];
   }
   return _filter(table, predicate);
 }

--- a/test/verbs/slice-test.js
+++ b/test/verbs/slice-test.js
@@ -1,0 +1,88 @@
+import tape from 'tape';
+import tableEqual from '../table-equal';
+import { table } from '../../src/verbs';
+
+tape('slice slices a table', t => {
+  const dt = table({ v: [1, 2, 3, 4] });
+
+  tableEqual(t,
+    dt.slice(),
+    { v: [1, 2, 3, 4] },
+    'sliced data, all'
+  );
+
+  tableEqual(t,
+    dt.slice(2),
+    { v: [3, 4] },
+    'sliced data, start'
+  );
+
+  tableEqual(t,
+    dt.slice(1, 3),
+    { v: [2, 3] },
+    'sliced data, start and end'
+  );
+
+  tableEqual(t,
+    dt.slice(1, -1),
+    { v: [2, 3] },
+    'sliced data, start and negative end'
+  );
+
+  tableEqual(t,
+    dt.slice(-3, -1),
+    { v: [2, 3] },
+    'sliced data, negative start and end'
+  );
+
+  tableEqual(t,
+    dt.slice(-1000, -900),
+    { v: [] },
+    'sliced data, extreme negative start and end'
+  );
+
+  t.end();
+});
+
+tape('slice slices a grouped table', t => {
+  const dt = table({ v: [1, 2, 3, 4, 5, 6, 7] })
+    .groupby({ k: d => d.v % 2 });
+
+  tableEqual(t,
+    dt.slice(),
+    { v: [1, 2, 3, 4, 5, 6, 7] },
+    'sliced data, all'
+  );
+
+  tableEqual(t,
+    dt.slice(2),
+    { v: [5, 6, 7] },
+    'sliced data, start'
+  );
+
+  tableEqual(t,
+    dt.slice(1, 3),
+    { v: [3, 4, 5, 6] },
+    'sliced data, start and end'
+  );
+
+  tableEqual(t,
+    dt.slice(1, -1),
+    { v: [3, 4, 5] },
+    'sliced data, start and negative end'
+  );
+
+  tableEqual(t,
+    dt.slice(-3, -1),
+    { v: [2, 3, 4, 5] },
+    'sliced data, negative start and end'
+  );
+
+  tableEqual(t,
+    dt.slice(-1000, -900),
+    { v: [] },
+    'sliced data, extreme negative start and end'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
* Add `slice()` verb to extract contiguous rows from table groups.

Closes #78.