### PR TITLE
Add Table.size getter.

### DIFF
--- a/src/table/table.js
+++ b/src/table/table.js
@@ -129,6 +129,16 @@ export default class Table extends Transformable {
   }
 
   /**
+   * The number of active rows in this table. This number may be
+   * less than the total rows if the table has been filtered.
+   * @see Table.totalRows
+   * @return {number} The number of rows.
+   */
+  get size() {
+    return this._nrows;
+  }
+
+  /**
    * The number of columns in this table.
    * @return {number} The number of columns.
    */


### PR DESCRIPTION
This makes the Table interface a bit more like the native Map and Set, which will similarly support a size getter.