### PR TITLE
Dedupe output should not be grouped.

### DIFF
--- a/src/verbs/dedupe.js
+++ b/src/verbs/dedupe.js
@@ -2,5 +2,6 @@ export default function(table, keys = []) {
   return table
     .groupby(keys.length ? keys : table.columnNames())
     .filter('row_number() === 1')
+    .ungroup()
     .reify();
 }

--- a/test/verbs/dedupe-test.js
+++ b/test/verbs/dedupe-test.js
@@ -12,6 +12,7 @@ tape('dedupe de-duplicates table', t => {
     a: [1, 2, 1],
     b: [3, 4, 5]
   }, 'dedupe data');
+  t.equal(dt.isGrouped(), false, 'dedupe not grouped');
   t.end();
 });
 
@@ -25,5 +26,6 @@ tape('dedupe de-duplicates table based on keys', t => {
     a: [1, 2],
     b: [3, 4]
   }, 'dedupe data');
+  t.equal(dt.isGrouped(), false, 'dedupe not grouped');
   t.end();
 });


### PR DESCRIPTION
- Fix `dedupe()` to produce ungrouped tables.