### PR TITLE
Update object/map functions.

### DIFF
--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -614,26 +614,33 @@ Compare two values for equality, using join semantics in which `null !== null`. 
 * *b*: The second input to compare.
 
 <hr/><a id="has" href="#has">#</a>
-<em>op</em>.<b>has</b>(<i>object</i>, <i>property</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
+<em>op</em>.<b>has</b>(<i>object</i>, <i>key</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
 
-Returns a boolean indicating whether the *object* has the specified *property* as its own property (as opposed to inheriting it).
+Returns a boolean indicating whether the *object* has the specified *key* as its own property (as opposed to inheriting it). If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) or [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance, the `has` method will be invoked directly on the object, otherwise `Object.hasOwnProperty` is used.
 
-* *object*: The object to test for property membership.
+* *object*: The object, Map, or Set to test for property membership.
 * *property*: The string property name to test for.
 
 <hr/><a id="keys" href="#keys">#</a>
 <em>op</em>.<b>keys</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
 
-Returns an array of a given *object*'s own enumerable property names.
+Returns an array of a given *object*'s own enumerable property names. If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) instance, the `keys` method will be invoked directly on the object, otherwise `Object.keys` is used.
 
-* *object*: The input object value.
+* *object*: The input object or Map value.
 
-<hr/><a id="values" href="#obj_values">#</a>
-<em>op</em>.<b>values</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
+<hr/><a id="vals" href="#vals">#</a>
+<em>op</em>.<b>vals</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
 
-Returns an array of a given *object*'s own enumerable property values.
+Returns an array of a given *object*'s own enumerable property values. If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) or [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance, the `values` method will be invoked directly on the object, otherwise `Object.values` is used.
 
-* *object*: The input object value.
+* *object*: The input object, Map, or Set value.
+
+<hr/><a id="entries" href="#entries">#</a>
+<em>op</em>.<b>entries</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
+
+Returns an array of a given *object*'s own enumerable string-keyed property `[key, value]` pairs. If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) or [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance, the `entries` method will be invoked directly on the object, otherwise `Object.entries` is used.
+
+* *object*: The input object, Map, or Set value.
 
 <hr/><a id="recode" href="#recode">#</a>
 <em>op</em>.<b>recode</b>(<i>value</i>, <i>map</i>[, <i>fallback</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/recode.js)

--- a/src/op/functions/object.js
+++ b/src/op/functions/object.js
@@ -1,7 +1,14 @@
 import has from '../../util/has';
+import isMap from '../../util/is-map';
+import isMapOrSet from '../../util/is-map-or-set';
+
+function array(iter) {
+  return Array.from(iter);
+}
 
 export default {
-  has:    (obj, property) => has(obj, property),
-  keys:   (obj) => Object.keys(obj),
-  values: (obj) => Object.values(obj)
+  has:     (obj, key) => isMapOrSet(obj) ? obj.has(key) : has(obj, key),
+  keys:    (obj) => isMap(obj) ? array(obj.keys()) : Object.keys(obj),
+  vals:    (obj) => isMapOrSet(obj) ? array(obj.values()) : Object.values(obj),
+  entries: (obj) => isMapOrSet(obj) ? array(obj.entries()) : Object.entries(obj)
 };

--- a/src/util/is-map-or-set.js
+++ b/src/util/is-map-or-set.js
@@ -1,0 +1,6 @@
+import isMap from './is-map';
+import isSet from './is-set';
+
+export default function(value) {
+  return isMap(value) || isSet(value);
+}

--- a/src/util/is-set.js
+++ b/src/util/is-set.js
@@ -1,0 +1,3 @@
+export default function(value) {
+  return value instanceof Set;
+}


### PR DESCRIPTION
- Add `op.vals()` to avoid collision with `op.values()` aggregation function.
- Add support for Map and Set instances to `op.has()`, `op.keys()`, and `op.vals()`.
- Add `op.entries()` function, with support for Object, Map, and Set instances.
