### PR TITLE
Resolve op.values collision by adding array_agg.

### DIFF
--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -18,7 +18,7 @@ title: Operations \| Arquero API Reference
   * [mean](#mean), [average](#average), [mode](#mode), [median](#median), [quantile](#quantile)
   * [stdev](#stdev), [stdevp](#stdevp), [variance](#variance), [variancep](#variance)
   * [corr](#corr), [covariance](#covariance), [covariancep](#covariancep)
-  * [values](#values), [unique](#unique)
+  * [array_agg](#array_agg), [array_agg_distinct](#array_agg_distinct)
 * [Window Functions](#window-functions)
   * [row_number](#row_number), [rank](#rank), [avg_rank](#avg_rank), [dense_rank](#dense_rank)
   * [percent_rank](#percent_rank), [cume_dist](#cume_dist), [ntile](#ntile)
@@ -628,8 +628,8 @@ Returns an array of a given *object*'s own enumerable property names. If the *ob
 
 * *object*: The input object or Map value.
 
-<hr/><a id="vals" href="#vals">#</a>
-<em>op</em>.<b>vals</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
+<hr/><a id="values" href="#values">#</a>
+<em>op</em>.<b>values</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
 
 Returns an array of a given *object*'s own enumerable property values. If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) or [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance, the `values` method will be invoked directly on the object, otherwise `Object.values` is used.
 
@@ -997,17 +997,17 @@ Aggregate function for the population covariance between two variables.
 * *field1*: The first data column or derived field.
 * *field2*: The second data column or derived field.
 
-<hr/><a id="values" href="#values">#</a>
-<em>op</em>.<b>values</b>(<i>field</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/aggregate-functions.js)
+<hr/><a id="array_agg" href="#array_agg">#</a>
+<em>op</em>.<b>array_agg</b>(<i>field</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/aggregate-functions.js)
 
 Aggregate function to collect an array of values. The resulting aggregate is an array containing all observed values.
 
 * *field*: The data column or derived field.
 
-<hr/><a id="unique" href="#unique">#</a>
-<em>op</em>.<b>unique</b>(<i>field</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/aggregate-functions.js)
+<hr/><a id="array_agg_distinct" href="#array_agg_distinct">#</a>
+<em>op</em>.<b>array_agg_distinct</b>(<i>field</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/aggregate-functions.js)
 
-Aggregate function to collect an array of unique values. The resulting aggregate is an array containing all unique values.
+Aggregate function to collect an array of distinct (unique) values. The resulting aggregate is an array containing all unique values.
 
 * *field*: The data column or derived field.
 

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -614,26 +614,33 @@ Compare two values for equality, using join semantics in which `null !== null`. 
 * *b*: The second input to compare.
 
 <hr/><a id="has" href="#has">#</a>
-<em>op</em>.<b>has</b>(<i>object</i>, <i>property</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
+<em>op</em>.<b>has</b>(<i>object</i>, <i>key</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
 
-Returns a boolean indicating whether the *object* has the specified *property* as its own property (as opposed to inheriting it).
+Returns a boolean indicating whether the *object* has the specified *key* as its own property (as opposed to inheriting it). If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) or [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance, the `has` method will be invoked directly on the object, otherwise `Object.hasOwnProperty` is used.
 
-* *object*: The object to test for property membership.
+* *object*: The object, Map, or Set to test for property membership.
 * *property*: The string property name to test for.
 
 <hr/><a id="keys" href="#keys">#</a>
 <em>op</em>.<b>keys</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
 
-Returns an array of a given *object*'s own enumerable property names.
+Returns an array of a given *object*'s own enumerable property names. If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) instance, the `keys` method will be invoked directly on the object, otherwise `Object.keys` is used.
 
-* *object*: The input object value.
+* *object*: The input object or Map value.
 
-<hr/><a id="values" href="#obj_values">#</a>
-<em>op</em>.<b>values</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
+<hr/><a id="vals" href="#vals">#</a>
+<em>op</em>.<b>vals</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
 
-Returns an array of a given *object*'s own enumerable property values.
+Returns an array of a given *object*'s own enumerable property values. If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) or [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance, the `values` method will be invoked directly on the object, otherwise `Object.values` is used.
 
-* *object*: The input object value.
+* *object*: The input object, Map, or Set value.
+
+<hr/><a id="entries" href="#entries">#</a>
+<em>op</em>.<b>entries</b>(<i>object</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/object.js)
+
+Returns an array of a given *object*'s own enumerable string-keyed property `[key, value]` pairs. If the *object* is a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) or [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance, the `entries` method will be invoked directly on the object, otherwise `Object.entries` is used.
+
+* *object*: The input object, Map, or Set value.
 
 <hr/><a id="recode" href="#recode">#</a>
 <em>op</em>.<b>recode</b>(<i>value</i>, <i>map</i>[, <i>fallback</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/recode.js)

--- a/src/engine/pivot.js
+++ b/src/engine/pivot.js
@@ -45,7 +45,11 @@ function pivotKeys(table, on, options) {
   // collect unique key values
   const uniq = aggregate(
     table.ungroup(),
-    [ { id: 0, name: 'unique', fields: [(row => kcol[row])], params: [] } ]
+    [ {
+      id: 0,
+      name: 'array_agg_distinct',
+      fields: [(row => kcol[row])], params: []
+    } ]
   )[0][0];
 
   // get ordered set of unique key values

--- a/src/op/aggregate-functions.js
+++ b/src/op/aggregate-functions.js
@@ -90,7 +90,7 @@ export default {
   },
 
   /** @type {AggregateDef} */
-  values: {
+  array_agg: {
     create: () => initOp({
       init: s => s.values = true,
       value: s => s.list.values().slice()
@@ -135,7 +135,7 @@ export default {
   },
 
   /** @type {AggregateDef} */
-  unique: {
+  array_agg_distinct: {
     create: () => initOp({
       value: s => s.distinct.values()
     }),
@@ -194,7 +194,7 @@ export default {
         : s.product /= v
     }),
     param: [1],
-    stream: ['values']
+    stream: ['array_agg']
   },
 
   /** @type {AggregateDef} */
@@ -271,7 +271,7 @@ export default {
       rem: (s, v) => { if (v <= s.min) s.min = NaN; }
     }),
     param: [1],
-    stream: ['values']
+    stream: ['array_agg']
   },
 
   /** @type {AggregateDef} */
@@ -283,7 +283,7 @@ export default {
       rem: (s, v) => { if (v >= s.max) s.max = NaN; }
     }),
     param: [1],
-    stream: ['values']
+    stream: ['array_agg']
   },
 
   /** @type {AggregateDef} */
@@ -292,7 +292,7 @@ export default {
       value: s => s.list.quantile(p)
     }),
     param: [1, 1],
-    req: ['values']
+    req: ['array_agg']
   },
 
   /** @type {AggregateDef} */
@@ -301,7 +301,7 @@ export default {
       value: s => s.list.quantile(0.5)
     }),
     param: [1],
-    req: ['values']
+    req: ['array_agg']
   },
 
   /** @type {AggregateDef} */

--- a/src/op/functions/object.js
+++ b/src/op/functions/object.js
@@ -1,7 +1,14 @@
 import has from '../../util/has';
+import isMap from '../../util/is-map';
+import isMapOrSet from '../../util/is-map-or-set';
+
+function array(iter) {
+  return Array.from(iter);
+}
 
 export default {
-  has:    (obj, property) => has(obj, property),
-  keys:   (obj) => Object.keys(obj),
-  values: (obj) => Object.values(obj)
+  has:     (obj, key) => isMapOrSet(obj) ? obj.has(key) : has(obj, key),
+  keys:    (obj) => isMap(obj) ? array(obj.keys()) : Object.keys(obj),
+  vals:    (obj) => isMapOrSet(obj) ? array(obj.values()) : Object.values(obj),
+  entries: (obj) => isMapOrSet(obj) ? array(obj.entries()) : Object.entries(obj)
 };

--- a/src/op/functions/object.js
+++ b/src/op/functions/object.js
@@ -9,6 +9,6 @@ function array(iter) {
 export default {
   has:     (obj, key) => isMapOrSet(obj) ? obj.has(key) : has(obj, key),
   keys:    (obj) => isMap(obj) ? array(obj.keys()) : Object.keys(obj),
-  vals:    (obj) => isMapOrSet(obj) ? array(obj.values()) : Object.values(obj),
+  values:  (obj) => isMapOrSet(obj) ? array(obj.values()) : Object.values(obj),
   entries: (obj) => isMapOrSet(obj) ? array(obj.entries()) : Object.entries(obj)
 };

--- a/src/op/op-api.js
+++ b/src/op/op-api.js
@@ -3,7 +3,7 @@ import Op from './op';
 
 export const any = (field) => Op('any', field);
 export const count = () => Op('count');
-export const unique = (field) => Op('unique', field);
+export const array_agg_distinct = (field) => Op('array_agg_distinct', field);
 
 /**
  * All table expression operations including normal functions,
@@ -30,7 +30,7 @@ export default {
    * @param {*} field The data field.
    * @return {number} The list of values.
    */
-  values: (field) => Op('values', field),
+  array_agg: (field) => Op('array_agg', field),
 
   /**
    * Aggregate function to count the number of valid values.
@@ -56,11 +56,11 @@ export default {
   distinct: (field) => Op('distinct', field),
 
   /**
-   * Aggregate function to collect an array of unique values.
+   * Aggregate function to collect an array of distinct (unique) values.
    * @param {*} field The data field.
    * @return {Array} The array of unique values.
    */
-  unique,
+  array_agg_distinct,
 
   /**
    * Aggregate function to determine the mode (most frequent) value.

--- a/src/util/is-map-or-set.js
+++ b/src/util/is-map-or-set.js
@@ -1,0 +1,6 @@
+import isMap from './is-map';
+import isSet from './is-set';
+
+export default function(value) {
+  return isMap(value) || isSet(value);
+}

--- a/src/util/is-set.js
+++ b/src/util/is-set.js
@@ -1,0 +1,3 @@
+export default function(value) {
+  return value instanceof Set;
+}

--- a/src/verbs/impute.js
+++ b/src/verbs/impute.js
@@ -2,7 +2,7 @@ import _impute from '../engine/impute';
 import _rollup from '../engine/rollup';
 import parse from '../expression/parse';
 import parseValues from './util/parse';
-import { unique } from '../op/op-api';
+import { array_agg_distinct } from '../op/op-api';
 import error from '../util/error';
 import toString from '../util/to-string';
 
@@ -28,6 +28,6 @@ export default function(table, values, options = {}) {
 // map direct field reference to "unique" aggregate
 function preparse(map) {
   map.forEach((value, key) =>
-    value.field ? map.set(key, unique(value + '')) : 0
+    value.field ? map.set(key, array_agg_distinct(value + '')) : 0
   );
 }

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -206,7 +206,7 @@ tape('derive supports streaming value windows', t => {
       index: () => op.row_number() - 1
     })
     .derive({
-      frame: rolling(op.values('index'), [-2, 0])
+      frame: rolling(op.array_agg('index'), [-2, 0])
     });
 
   tableEqual(t, dt,
@@ -241,8 +241,8 @@ tape('derive supports bigint values', t => {
       min:  op.min('v'),
       max:  op.max('v'),
       med:  op.median('v'),
-      vals: op.values('v'),
-      uniq: op.unique('v')
+      vals: op.array_agg('v'),
+      uniq: op.array_agg_distinct('v')
     }));
 
   t.deepEqual(

--- a/test/verbs/rollup-test.js
+++ b/test/verbs/rollup-test.js
@@ -94,8 +94,8 @@ tape('rollup supports bigint values', t => {
       min:  op.min('v'),
       max:  op.max('v'),
       med:  op.median('v'),
-      vals: op.values('v'),
-      uniq: op.unique('v')
+      vals: op.array_agg('v'),
+      uniq: op.array_agg_distinct('v')
     });
 
   t.deepEqual(

--- a/test/verbs/unroll-test.js
+++ b/test/verbs/unroll-test.js
@@ -126,7 +126,7 @@ tape('unroll can invert a rollup', t => {
 
   const ut = table(data)
     .groupby('k')
-    .rollup({ x: d => op.values(d.x) })
+    .rollup({ x: d => op.array_agg(d.x) })
     .unroll('x');
 
   tableEqual(t, ut, data, 'unroll rollup data');


### PR DESCRIPTION
- (_Breaking_) Rename `op.values` aggregation function to `op.array_agg`.
- (_Breaking_) Rename `op.unique` aggregation function to `op.array_agg_distinct`.
- Add support for Map and Set instances to `op.has()`, `op.keys()`, and `op.values()`.
- Add `op.entries()` function, with support for Object, Map, and Set instances.

This PR is an alternative to #104, but requires a major version bump.