### PR TITLE
Fix codegen for computed object keys.

### DIFF
--- a/src/expression/codegen.js
+++ b/src/expression/codegen.js
@@ -79,7 +79,8 @@ const visitors = {
     return '({' + list(node.properties, opt) + '})';
   },
   Property: (node, opt) => {
-    return visit(node.key, opt) + ':' + visit(node.value, opt);
+    const key = visit(node.key, opt);
+    return (node.computed ? `[${key}]` : key ) + ':' + visit(node.value, opt);
   },
 
   ArrowFunctionExpression: func,

--- a/test/expression/parse-test.js
+++ b/test/expression/parse-test.js
@@ -271,6 +271,16 @@ tape('parse throws on invalid op parameter expressions', t => {
   t.end();
 });
 
+tape('parse parses computed object properties', t => {
+  const { exprs } = parse({ f: d => ({ [d.x]: d.y }) });
+  t.equal(
+    exprs[0] + '',
+    '(row,data,op)=>({[data.x.get(row)]:data.y.get(row)})',
+    'parsed computed object property'
+  );
+  t.end();
+});
+
 tape('parse parses template literals', t => {
   const { exprs } = parse({ f: d => `${d.x} + ${d.y}` });
   t.equal(


### PR DESCRIPTION
- Fix table expression code generation for computed object keys (`{['a'+'b']: 'c'}`)