### PR TITLE
Add default row index for table.get.

### DIFF
--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -305,12 +305,12 @@ t1.assign(t2); // { a: [1, 2], b: [7, 8], c: [5, 6] }
 Returns the internal table storage data structure.
 
 <hr/><a id="get" href="#get">#</a>
-<em>table</em>.<b>get</b>(<i>name</i>, <i>row</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
+<em>table</em>.<b>get</b>(<i>name</i>[, <i>row</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
 
 Get the value for the given column and row. Row indices are relative to any filtering and ordering criteria, not the internal data layout.
 
 * *name*: The column name.
-* *row*: The row index, relative to any filtering or ordering criteria.
+* *row*: The row index (default `0`), relative to any filtering or ordering criteria.
 
 *Examples*
 

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -132,10 +132,10 @@ export default class ColumnTable extends Table {
   /**
    * Get the value for the given column and row.
    * @param {string} name The column name.
-   * @param {number} row The row index.
+   * @param {number} [row=0] The row index, defaults to zero if not specified.
    * @return {import('./table').DataValue} The table value at (column, row).
    */
-  get(name, row) {
+  get(name, row = 0) {
     const column = this.column(name);
     return this.isFiltered() || this.isOrdered()
       ? column.get(this.indices()[row])

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -197,10 +197,10 @@ export default class Table extends Transformable {
   /**
    * Get the value for the given column and row.
    * @param {string} name The column name.
-   * @param {number} row The row index.
+   * @param {number} [row=0] The row index, defaults to zero if not specified.
    * @return {DataValue} The data value at (column, row).
    */
-  get(name, row) { // eslint-disable-line no-unused-vars
+  get(name, row = 0) { // eslint-disable-line no-unused-vars
     error('Not implemented');
   }
 


### PR DESCRIPTION
- Update `table.get(columnName, row)` to default to row index `0` when `row` is unspecified.