### PR TITLE
v4.1.0

### DIFF
--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -8,6 +8,7 @@ title: Operations \| Arquero API Reference
 * [Standard Functions](#functions)
   * [Array Functions](#array-functions)
   * [Date Functions](#date-functions)
+  * [JSON Functions](#json-functions)
   * [Math Functions](#math-functions)
   * [Object Functions](#object-functions)
   * [String Functions](#string-functions)
@@ -338,6 +339,26 @@ Returns an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted string f
 
 * *date*: The input Date or timestamp value.
 * *shorten*: A boolean flag (default `false`) indicating if the formatted string should be shortened if possible. For example, the UTC date `2001-01-01` will shorten from `"2001-01-01T00:00:00.000Z"` to `"2001-01-01"`.
+
+<br>
+
+### <a id="json-functions">JSON Functions</a>
+
+Functions for parsing and generating strings formatted using [JavaScript Object Notation (JSON)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON).
+
+<hr/><a id="parse_json" href="#parse_json">#</a>
+<em>op</em>.<b>parse_json</b>(<i>value</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/json.js)
+
+Parses a string *value* in [JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) format, constructing the JavaScript value or object described by the string.
+
+* *value*: The input string value.
+
+<hr/><a id="to_json" href="#to_json">#</a>
+<em>op</em>.<b>to_json</b>(<i>value</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/op/functions/json.js)
+
+Converts a JavaScript object or value to a [JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) string.
+
+* *value*: The value to convert to a JSON string.
 
 <br>
 

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -388,6 +388,7 @@ Returns an array of objects representing table rows. A new set of objects will b
 * *options*: Options for row generation:
   * *limit*: The maximum number of objects to create (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
+  * *columns*: An ordered set of columns to include. The input may consist of: column name strings, column integer indices, objects with current column names as keys and new column names as values (for renaming), or a selection helper function such as [all](#all), [not](#not), or [range](#range)).
 
 *Examples*
 
@@ -422,6 +423,7 @@ Print the contents of this table using the `console.table()` method.
 * *options*: Options for printing. If number-valued, specifies the row limit (equivalent to `{ limit: value }`).
   * *limit*: The maximum number of rows to print (default `10`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
+  * *columns*: An ordered set of columns to print. The input may consist of: column name strings, column integer indices, objects with current column names as keys and new column names as values (for renaming), or a selection helper function such as [all](#all), [not](#not), or [range](#range)).
 
 *Examples*
 

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -389,12 +389,23 @@ Returns an array of objects representing table rows. A new set of objects will b
   * *limit*: The maximum number of objects to create (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: An ordered set of columns to include. The input may consist of: column name strings, column integer indices, objects with current column names as keys and new column names as values (for renaming), or a selection helper function such as [all](#all), [not](#not), or [range](#range)).
+  * *grouped*: The export format for groups of rows. This option only applies to tables with groups set with the [groupby](verbs/#groupby) verb. The default (`false`) is to ignore groups, returning a flat array of objects. The valid values are `true` or `'map'` (for [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) instances), `'object'` (for standard [Objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)), or `'entries'` (for arrays in the style of [Object.entries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)). For the `'object'` format, groupby keys are coerced to strings to use as object property names; note that this can lead to undesirable behavior if the groupby keys are object values. The `'map'` and `'entries'` options preserve the groupby key values.
 
 *Examples*
 
 ```js
 aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).objects()
 // [ { a: 1, b: 4 }, { a: 2, b: 5 }, { a: 3, b: 6 } ]
+```
+
+```js
+aq.table({ k: ['a', 'b', 'a'], v: [1, 2, 3] })
+  .groupby('k')
+  .objects({ grouped: true })
+// new Map([
+//   [ 'a', [ { k: 'a', v: 1 }, { k: 'a', v: 3 } ] ],
+//   [ 'b', [ { k: 'b', v: 2 } ] ]
+// ])
 ```
 
 <hr/><a id="@@iterator" href="#@@iterator">#</a>

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -305,12 +305,12 @@ t1.assign(t2); // { a: [1, 2], b: [7, 8], c: [5, 6] }
 Returns the internal table storage data structure.
 
 <hr/><a id="get" href="#get">#</a>
-<em>table</em>.<b>get</b>(<i>name</i>, <i>row</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
+<em>table</em>.<b>get</b>(<i>name</i>[, <i>row</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
 
 Get the value for the given column and row. Row indices are relative to any filtering and ordering criteria, not the internal data layout.
 
 * *name*: The column name.
-* *row*: The row index, relative to any filtering or ordering criteria.
+* *row*: The row index (default `0`), relative to any filtering or ordering criteria.
 
 *Examples*
 

--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -194,6 +194,7 @@ Generate a table from a random sample of rows. If the table is grouped, perform 
 * *size*: The number of samples to draw per group. If number-valued, the same sample size is used for each group. If function-valued, the input should be an aggregate table expression compatible with [rollup](#rollup).
 * *options*: An options object:
   * *replace*: Boolean flag (default `false`) to sample with replacement.
+  * *shuffle*: Boolean flag (default `true`) to ensure randomly ordered rows.
   * *weight*: Column values to use as weights for sampling. Rows will be sampled with probability proportional to their relative weight. The input should be a column name string or a table expression compatible with [derive](#derive).
 
 *Examples*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arquero",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Query processing and transformation of array-backed data tables.",
   "keywords": [
     "data",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "^7.22.0",
     "esm": "^3.2.25",
     "rimraf": "^3.0.2",
-    "rollup": "^2.41.2",
+    "rollup": "^2.42.3",
     "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-terser": "^7.0.2",
     "tape": "^5.2.2",

--- a/src/engine/sample.js
+++ b/src/engine/sample.js
@@ -1,7 +1,8 @@
 import sample from '../util/sample';
+import _shuffle from '../util/shuffle';
 
 export default function(table, size, weight, options = {}) {
-  const replace = !!options.replace;
+  const { replace, shuffle } = options;
   const parts = table.partitions(false);
 
   let total = 0;
@@ -26,6 +27,12 @@ export default function(table, size, weight, options = {}) {
       sample(buf, replace, idx, weight);
     }
   });
+
+  if (shuffle !== false && (parts.length > 1 || !replace)) {
+    // sampling with replacement methods shuffle, so in
+    // that case a single partition is already good to go
+    _shuffle(samples);
+  }
 
   return table.reify(samples);
 }

--- a/src/engine/window/window.js
+++ b/src/engine/window/window.js
@@ -72,7 +72,7 @@ function windowStates(ops, data) {
 
   return Object.values(map).map(_ => windowState(
     data, _.frame, _.peers, _.winOps,
-    reducers(_.aggOps, _.frame[0] != null)
+    reducers(_.aggOps, _.frame[0] != null ? -1 : 1)
   ));
 }
 

--- a/src/op/aggregate-functions.js
+++ b/src/op/aggregate-functions.js
@@ -93,7 +93,7 @@ export default {
   array_agg: {
     create: () => initOp({
       init: s => s.values = true,
-      value: s => s.list.values().slice()
+      value: s => s.list.values(s.stream)
     }),
     param: [1]
   },

--- a/src/op/aggregate-functions.js
+++ b/src/op/aggregate-functions.js
@@ -108,6 +108,24 @@ export default {
   },
 
   /** @type {AggregateDef} */
+  map_agg: {
+    create: () => initOp({
+      init:  s => s.values = true,
+      value: s => new Map(s.list.values())
+    }),
+    param: [2]
+  },
+
+  /** @type {AggregateDef} */
+  entries_agg: {
+    create: () => initOp({
+      init:  s => s.values = true,
+      value: s => s.list.values(s.stream)
+    }),
+    param: [2]
+  },
+
+  /** @type {AggregateDef} */
   any: {
     create: () => initOp({
       add: (s, v) => { if (s.any == null) s.any = v; },

--- a/src/op/functions/index.js
+++ b/src/op/functions/index.js
@@ -2,6 +2,7 @@ import array from './array';
 import bin from './bin';
 import date from './date';
 import equal from './equal';
+import json from './json';
 import math from './math';
 import object from './object';
 import recode from './recode';
@@ -15,6 +16,7 @@ export default {
   sequence,
   ...array,
   ...date,
+  ...json,
   ...math,
   ...object,
   ...string

--- a/src/op/functions/json.js
+++ b/src/op/functions/json.js
@@ -1,0 +1,4 @@
+export default {
+  parse_json: (str) => JSON.parse(str),
+  to_json:    (val) => JSON.stringify(val)
+};

--- a/src/op/op-api.js
+++ b/src/op/op-api.js
@@ -3,7 +3,11 @@ import Op from './op';
 
 export const any = (field) => Op('any', field);
 export const count = () => Op('count');
+export const array_agg = (field) => Op('array_agg', field);
 export const array_agg_distinct = (field) => Op('array_agg_distinct', field);
+export const map_agg = (key, value) => Op('map_agg', [key, value]);
+export const object_agg = (key, value) => Op('object_agg', [key, value]);
+export const entries_agg = (key, value) => Op('entries_agg', [key, value]);
 
 /**
  * All table expression operations including normal functions,
@@ -30,7 +34,7 @@ export default {
    * @param {*} field The data field.
    * @return {Array} The list of values.
    */
-  array_agg: (field) => Op('array_agg', field),
+  array_agg,
 
   /**
    * Aggregate function to collect an array of distinct (unique) values.
@@ -45,7 +49,7 @@ export default {
    * @param {*} value The object value field.
    * @return {object} The object of key-value pairs.
    */
-  object_agg: (key, value) => Op('object_agg', [key, value]),
+  object_agg,
 
   /**
    * Aggregate function to create a Map given input key and value fields.
@@ -53,7 +57,7 @@ export default {
    * @param {*} value The object value field.
    * @return {Map} The Map of key-value pairs.
    */
-  map_agg: (key, value) => Op('map_agg', [key, value]),
+  map_agg,
 
   /**
    * Aggregate function to create an array in the style of Object.entries()
@@ -62,7 +66,7 @@ export default {
    * @param {*} value The object value field.
    * @return {Array} The array of [key, value] arrays.
    */
-  entries_agg: (key, value) => Op('entries_agg', [key, value]),
+  entries_agg,
 
   /**
    * Aggregate function to count the number of valid values.

--- a/src/op/op-api.js
+++ b/src/op/op-api.js
@@ -43,9 +43,26 @@ export default {
    * Aggregate function to create an object given input key and value fields.
    * @param {*} key The object key field.
    * @param {*} value The object value field.
-   * @return {object} The array of unique values.
+   * @return {object} The object of key-value pairs.
    */
   object_agg: (key, value) => Op('object_agg', [key, value]),
+
+  /**
+   * Aggregate function to create a Map given input key and value fields.
+   * @param {*} key The object key field.
+   * @param {*} value The object value field.
+   * @return {Map} The Map of key-value pairs.
+   */
+  map_agg: (key, value) => Op('map_agg', [key, value]),
+
+  /**
+   * Aggregate function to create an array in the style of Object.entries()
+   * given input key and value fields.
+   * @param {*} key The object key field.
+   * @param {*} value The object value field.
+   * @return {Array} The array of [key, value] arrays.
+   */
+  entries_agg: (key, value) => Op('entries_agg', [key, value]),
 
   /**
    * Aggregate function to count the number of valid values.

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -132,10 +132,10 @@ export default class ColumnTable extends Table {
   /**
    * Get the value for the given column and row.
    * @param {string} name The column name.
-   * @param {number} row The row index.
+   * @param {number} [row=0] The row index, defaults to zero if not specified.
    * @return {import('./table').DataValue} The table value at (column, row).
    */
-  get(name, row) {
+  get(name, row = 0) {
     const column = this.column(name);
     return this.isFiltered() || this.isOrdered()
       ? column.get(this.indices()[row])

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -8,6 +8,7 @@ import toCSV from '../format/to-csv';
 import toHTML from '../format/to-html';
 import toJSON from '../format/to-json';
 import toMarkdown from '../format/to-markdown';
+import resolve, { all } from '../helpers/selection';
 import arrayType from '../util/array-type';
 import error from '../util/error';
 import mapObject from '../util/map-object';
@@ -163,7 +164,8 @@ export default class ColumnTable extends Table {
    * @return {object[]} An array of row objects.
    */
   objects(options = {}) {
-    const create = rowObjectBuilder(this);
+    const names = resolve(this, options.columns || all());
+    const create = rowObjectBuilder(this, names);
     const tuples = [];
     this.scan(row => {
       tuples.push(create(row));

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -19,11 +19,13 @@ Object.assign(ColumnTable.prototype, verbs);
  * @example table({ colA: ['a', 'b', 'c'], colB: [3, 4, 5] })
  */
 export function table(columns, names) {
-  const cols = entries(columns);
-  return new ColumnTable(
-    cols.reduce((obj, [k, v]) => (obj[k] = v, obj), {}),
-    names || cols.map(c => c[0])
-  );
+  const data = {};
+  const keys = [];
+  for (const [key, value] of entries(columns)) {
+    data[key] = value;
+    keys.push(key);
+  }
+  return new ColumnTable(data, names || keys);
 }
 
 /**

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -234,7 +234,7 @@ export default class Table extends Transformable {
 
   /**
    * Print the contents of this table using the console.table() method.
-   * @param {ObjectsOptions|number} options The options for row object
+   * @param {PrintOptions|number} options The options for row object
    *  generation, determining which rows and columns are printed. If
    *  number-valued, specifies the row limit.
    */
@@ -245,7 +245,7 @@ export default class Table extends Transformable {
       options.limit = 10;
     }
 
-    const obj = this.objects(options);
+    const obj = this.objects({ ...options, grouped: false });
     const msg = `${this[Symbol.toStringTag]}. Showing ${obj.length} rows.`;
 
     console.log(msg);   // eslint-disable-line no-console
@@ -522,12 +522,32 @@ export default class Table extends Transformable {
 
 /**
  * Options for generating row objects.
- * @typedef {object} ObjectsOptions
+ * @typedef {object} PrintOptions
  * @property {number} [limit=Infinity] The maximum number of objects to create.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
- * @property {import('../table/transformable').Select} columns
+ * @property {import('../table/transformable').Select} [columns]
  *  An ordered set of columns to include. The input may consist of column name
  *  strings, column integer indices, objects with current column names as keys
  *  and new column names as values (for renaming), or selection helper
  *  functions such as {@link all}, {@link not}, or {@link range}.
+ */
+
+/**
+ * Options for generating row objects.
+ * @typedef {object} ObjectsOptions
+ * @property {number} [limit=Infinity] The maximum number of objects to create.
+ * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
+ * @property {import('../table/transformable').Select} [columns]
+ *  An ordered set of columns to include. The input may consist of column name
+ *  strings, column integer indices, objects with current column names as keys
+ *  and new column names as values (for renaming), or selection helper
+ *  functions such as {@link all}, {@link not}, or {@link range}.
+ * @property {'map'|'entries'|'object'|boolean} [grouped=false]
+ *  The export format for groups of rows. The default (false) is to ignore
+ *  groups, returning a flat array of objects. The valid values are 'map' or
+ *  true (for Map instances), 'object' (for standard objects), or 'entries'
+ *  (for arrays in the style of Object.entries). For the 'object' format,
+ *  groupby keys are coerced to strings to use as object property names; note
+ *  that this can lead to undesirable behavior if the groupby keys are object
+ *  values. The 'map' and 'entries' options preserve the groupby key values.
  */

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -525,4 +525,9 @@ export default class Table extends Transformable {
  * @typedef {object} ObjectsOptions
  * @property {number} [limit=Infinity] The maximum number of objects to create.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
+ * @property {import('../table/transformable').Select} columns
+ *  An ordered set of columns to include. The input may consist of column name
+ *  strings, column integer indices, objects with current column names as keys
+ *  and new column names as values (for renaming), or selection helper
+ *  functions such as {@link all}, {@link not}, or {@link range}.
  */

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -197,10 +197,10 @@ export default class Table extends Transformable {
   /**
    * Get the value for the given column and row.
    * @param {string} name The column name.
-   * @param {number} row The row index.
+   * @param {number} [row=0] The row index, defaults to zero if not specified.
    * @return {DataValue} The data value at (column, row).
    */
-  get(name, row) { // eslint-disable-line no-unused-vars
+  get(name, row = 0) { // eslint-disable-line no-unused-vars
     error('Not implemented');
   }
 

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -865,6 +865,7 @@ export default class Transformable {
  * Options for sample transformations.
  * @typedef {object} SampleOptions
  * @property {boolean} [replace=false] Flag for sampling with replacement.
+ * @property {boolean} [shuffle=true] Flag to ensure randomly ordered rows.
  * @property {string|TableExpr} [weight] Column values to use as weights
  *  for sampling. Rows will be sampled with probability proportional to
  *  their relative weight. The input should be a column name string or

--- a/src/util/row-object-builder.js
+++ b/src/util/row-object-builder.js
@@ -1,10 +1,17 @@
+import entries from './entries';
+import isArray from './is-array';
 import unroll from './unroll';
 
 export default function(table, names) {
-  names = names || table.columnNames();
-  return unroll(
-    'row',
-    '({' + names.map((_, i) => `${JSON.stringify(_)}:_${i}.get(row)`) + '})',
-    names.map(name => table.column(name))
-  );
+  const props = [];
+  const cols = [];
+  let i = -1;
+
+  for (const entry of entries(names || table.columnNames())) {
+    const [name, key] = isArray(entry) ? entry : [entry, entry];
+    props.push(`${JSON.stringify(key)}:_${++i}.get(row)`);
+    cols.push(table.column(name));
+  }
+
+  return unroll('row', '({' + props + '})', cols);
 }

--- a/src/util/shuffle.js
+++ b/src/util/shuffle.js
@@ -1,0 +1,14 @@
+import { random } from './random';
+
+export default function(array, lo = 0, hi = array.length) {
+  let n = hi - (lo = +lo);
+
+  while (n) {
+    const i = random() * n-- | 0;
+    const v = array[n + lo];
+    array[n + lo] = array[i + lo];
+    array[i + lo] = v;
+  }
+
+  return array;
+}

--- a/src/util/unique-name.js
+++ b/src/util/unique-name.js
@@ -1,0 +1,13 @@
+import isMapOrSet from './is-map-or-set';
+
+export default function(names, name) {
+  names = isMapOrSet(names) ? names : new Set(names);
+  let uname = name;
+  let index = 0;
+
+  while (names.has(uname)) {
+    uname = name + ++index;
+  }
+
+  return uname;
+}

--- a/src/util/value-list.js
+++ b/src/util/value-list.js
@@ -5,21 +5,19 @@ import quantile from './quantile';
 
 export default class ValueList {
   constructor(values) {
-    this.values(values || []);
+    this._values = values || [];
+    this._sorted = null;
+    this._start = 0;
   }
 
-  values(values) {
-    if (arguments.length) {
-      this._values = values;
-      this._sorted = null;
+  values(copy) {
+    if (this._start) {
+      this._values = this._values.slice(this._start);
       this._start = 0;
-    } else {
-      if (this._start) {
-        this._values = this._values.slice(this._start);
-        this._start = 0;
-      }
-      return this._values;
     }
+    return copy
+      ? this._values.slice()
+      : this._values;
   }
 
   add(value) {
@@ -46,7 +44,7 @@ export default class ValueList {
 
   quantile(p) {
     if (!this._sorted) {
-      this._sorted = this.values().slice();
+      this._sorted = this.values(true);
       this._sorted.sort(ascending);
     }
     return quantile(this._sorted, p);

--- a/test/op/json-test.js
+++ b/test/op/json-test.js
@@ -1,0 +1,29 @@
+import tape from 'tape';
+import { op } from '../../src';
+
+tape('op.parse_json parses json strings', t => {
+  t.deepEqual([
+    op.parse_json('1'),
+    op.parse_json('[3,2,1.2]'),
+    op.parse_json('{"foo":true,"bar":"bop","baz":null}')
+  ], [
+    1,
+    [3, 2, 1.2],
+    {foo: true, bar: 'bop', baz: null}
+  ], 'parse_json');
+  t.end();
+});
+
+tape('op.to_json generates json strings', t => {
+  t.deepEqual([
+    op.to_json(1),
+    op.to_json([3, 2, 1.2]),
+    op.to_json({foo: true, bar: 'bop', baz: null, buz: undefined})
+  ], [
+    '1',
+    '[3,2,1.2]',
+    '{"foo":true,"bar":"bop","baz":null}'
+
+  ], 'to_json');
+  t.end();
+});

--- a/test/query/query-test.js
+++ b/test/query/query-test.js
@@ -521,7 +521,7 @@ tape('Query evaluates sample verbs', t => {
     Query.from(
       new Query([sample(2, { replace: true })]).toObject()
     ).evaluate(dt),
-    { foo: [ 2, 2 ], bar: [ 0, 0 ] },
+    { foo: [ 3, 0 ], bar: [ 0, 1 ] },
     'sample query result, replace'
   );
 
@@ -530,7 +530,7 @@ tape('Query evaluates sample verbs', t => {
     Query.from(
       new Query([sample(2, { weight: 'foo' })]).toObject()
     ).evaluate(dt),
-    { foo: [ 3, 2 ], bar: [ 0, 0 ] },
+    { foo: [ 2, 3 ], bar: [ 0, 0 ] },
     'sample query result, weight column name'
   );
 
@@ -539,7 +539,7 @@ tape('Query evaluates sample verbs', t => {
     Query.from(
       new Query([sample(2, { weight: d => d.foo })]).toObject()
     ).evaluate(dt),
-    { foo: [ 3, 1 ], bar: [ 0, 1 ] },
+    { foo: [ 3, 2 ], bar: [ 0, 0 ] },
     'sample query result, weight table expression'
   );
 

--- a/test/table/column-table-test.js
+++ b/test/table/column-table-test.js
@@ -1,5 +1,6 @@
 import tape from 'tape';
 import tableEqual from '../table-equal';
+import { not } from '../../src/helpers/selection';
 import BitSet from '../../src/table/bit-set';
 import ColumnTable from '../../src/table/column-table';
 
@@ -138,6 +139,18 @@ tape('ColumnTable supports object output', t => {
     dt.objects({ limit: 3 }),
     output.slice(0, 3),
     'object data with limit'
+  );
+
+  t.deepEqual(
+    dt.objects({ columns: not('v') }),
+    output.map(d => ({ u: d.u })),
+    'object data with column selection'
+  );
+
+  t.deepEqual(
+    dt.objects({ columns: { u: 'a', v: 'b'} }),
+    output.map(d => ({ a: d.u, b: d.v })),
+    'object data with renaming column selection'
   );
 
   t.end();

--- a/test/table/column-table-test.js
+++ b/test/table/column-table-test.js
@@ -156,6 +156,174 @@ tape('ColumnTable supports object output', t => {
   t.end();
 });
 
+tape('ColumnTable supports grouped object output', t => {
+  const dt = new ColumnTable({
+      u: ['a', 'a', 'a', 'b', 'b'],
+      v: [2, 1, 4, 5, 3]
+    })
+    .orderby('v');
+
+  t.deepEqual(
+    dt.groupby('u').objects({ grouped: 'object' }),
+    {
+      a: [
+        { u: 'a', v: 1 },
+        { u: 'a', v: 2 },
+        { u: 'a', v: 4 }
+      ],
+      b: [
+        { u: 'b', v: 3 },
+        { u: 'b', v: 5 }
+      ]
+    },
+    'grouped object output'
+  );
+
+  t.deepEqual(
+    dt.groupby('u').objects({ grouped: 'entries' }),
+    [
+      ['a',[
+        { u: 'a', v: 1 },
+        { u: 'a', v: 2 },
+        { u: 'a', v: 4 }
+      ]],
+      ['b',[
+        { u: 'b', v: 3 },
+        { u: 'b', v: 5 }
+      ]]
+    ],
+    'grouped entries output'
+  );
+
+  t.deepEqual(
+    dt.groupby('u').objects({ grouped: 'map' }),
+    new Map([
+      ['a',[
+        { u: 'a', v: 1 },
+        { u: 'a', v: 2 },
+        { u: 'a', v: 4 }
+      ]],
+      ['b',[
+        { u: 'b', v: 3 },
+        { u: 'b', v: 5 }
+      ]]
+    ]),
+    'grouped map output'
+  );
+
+  t.deepEqual(
+    dt.groupby('u').objects({ grouped: true }),
+    new Map([
+      ['a',[
+        { u: 'a', v: 1 },
+        { u: 'a', v: 2 },
+        { u: 'a', v: 4 }
+      ]],
+      ['b',[
+        { u: 'b', v: 3 },
+        { u: 'b', v: 5 }
+      ]]
+    ]),
+    'grouped map output, using true'
+  );
+
+  t.deepEqual(
+    dt.filter(d => d.v < 4).groupby('u').objects({ grouped: 'object' }),
+    {
+      a: [
+        { u: 'a', v: 1 },
+        { u: 'a', v: 2 }
+      ],
+      b: [
+        { u: 'b', v: 3 }
+      ]
+    },
+    'grouped object output, with filter'
+  );
+
+  t.deepEqual(
+    dt.groupby('u').objects({ limit: 3, grouped: 'object' }),
+    {
+      a: [
+        { u: 'a', v: 1 },
+        { u: 'a', v: 2 }
+      ],
+      b: [
+        { u: 'b', v: 3 }
+      ]
+    },
+    'grouped object output, with limit'
+  );
+
+  t.deepEqual(
+    dt.groupby('u').objects({ offset: 2, grouped: 'object' }),
+    {
+      a: [
+        { u: 'a', v: 4 }
+      ],
+      b: [
+        { u: 'b', v: 3 },
+        { u: 'b', v: 5 }
+      ]
+    },
+    'grouped object output, with offset'
+  );
+
+  const dt2 = new ColumnTable({
+      u: ['a', 'a', 'a', 'b', 'b'],
+      w: ['y', 'x', 'y', 'z', 'x'],
+      v: [2, 1, 4, 5, 3]
+    })
+    .orderby('v');
+
+  t.deepEqual(
+    dt2.groupby(['u', 'w']).objects({ grouped: 'object' }),
+    {
+      a: {
+        x: [{ u: 'a', w: 'x', v: 1 }],
+        y: [{ u: 'a', w: 'y', v: 2 },{ u: 'a', w: 'y', v: 4 }]
+      },
+      b: {
+        x: [{ u: 'b', w: 'x', v: 3 }],
+        z: [{ u: 'b', w: 'z', v: 5 }]
+      }
+    },
+    'grouped nested object output'
+  );
+
+  t.deepEqual(
+    dt2.groupby(['u', 'w']).objects({ grouped: 'entries' }),
+    [
+      ['a', [
+        ['y', [{ u: 'a', w: 'y', v: 2 }, { u: 'a', w: 'y', v: 4 }]],
+        ['x', [{ u: 'a', w: 'x', v: 1 }]]
+      ]],
+      ['b', [
+        ['z', [{ u: 'b', w: 'z', v: 5 }]],
+        ['x', [{ u: 'b', w: 'x', v: 3 }]]
+      ]]
+    ],
+    'grouped nested entries output'
+  );
+
+  t.deepEqual(
+    dt2.groupby(['u', 'w']).objects({ grouped: 'map' }),
+    new Map([
+      ['a', new Map([
+        ['x', [{ u: 'a', w: 'x', v: 1 }]],
+        ['y', [{ u: 'a', w: 'y', v: 2 },{ u: 'a', w: 'y', v: 4 }]]
+      ])],
+      ['b', new Map([
+        ['x', [{ u: 'b', w: 'x', v: 3 }]],
+        ['z', [{ u: 'b', w: 'z', v: 5 }]]
+      ])]
+    ]),
+    'grouped nested map output'
+  );
+
+  t.end();
+});
+
 tape('ColumnTable supports iterator output', t => {
   const output = [
     { u: 'a', v: 2 },

--- a/test/verbs/rollup-test.js
+++ b/test/verbs/rollup-test.js
@@ -119,25 +119,45 @@ tape('rollup supports bigint values', t => {
   t.end();
 });
 
-tape('rollup supports object_agg function', t => {
+tape('rollup supports object_agg functions', t => {
   const data = {
     g: [0, 0, 1, 1, 1],
     k: ['a', 'b', 'a', 'b', 'a'],
     v: [1, 2, 3, 4, 5]
   };
 
-  const dt = table(data)
-    .groupby('g')
-    .rollup({ o: op.object_agg('k', 'v') });
+  const dt = table(data).groupby('g');
 
   t.deepEqual(
-    dt.columnArray('o'),
+    dt.rollup({ o: op.object_agg('k', 'v') })
+      .columnArray('o'),
     [
       { a: 1, b: 2 },
       { a: 5, b: 4 }
     ],
-    'rollup data'
+    'rollup data - object_agg'
   );
+
+  t.deepEqual(
+    dt.rollup({ o: op.entries_agg('k', 'v') })
+      .columnArray('o'),
+    [
+      [['a', 1], ['b', 2]],
+      [['a', 3], ['b', 4], ['a', 5]]
+    ],
+    'rollup data - entries_agg'
+  );
+
+  t.deepEqual(
+    dt.rollup({ o: op.map_agg('k', 'v') })
+      .columnArray('o'),
+    [
+      new Map([['a', 1], ['b', 2]]),
+      new Map([['a', 5], ['b', 4]])
+    ],
+    'rollup data - map_agg'
+  );
+
   t.end();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,14 +84,14 @@
   integrity sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA==
 
 "@types/node@*":
-  version "14.14.34"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.34.tgz#07935194fc049069a1c56c0c274265abeddf88da"
-  integrity sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
+  version "14.14.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
+  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
 "@types/node@^12.0.4":
-  version "12.20.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.5.tgz#4ca82a766f05c359fd6c77505007e5a272f4bb9b"
-  integrity sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg==
+  version "12.20.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.6.tgz#7b73cce37352936e628c5ba40326193443cfba25"
+  integrity sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==
 
 "@types/resolve@1.17.1":
   version "1.17.1"
@@ -131,9 +131,9 @@ ajv@^6.10.0, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^7.0.2:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.1.tgz#a5ac226171912447683524fa2f1248fcf8bac83d"
-  integrity sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-7.2.3.tgz#ca78d1cf458d7d36d1c3fa0794dd143406db5772"
+  integrity sha512-idv5WZvKVXDqKralOImQgPM9v6WOdLNa0IY3B3doOjw/YxRGT8I+allIJ6kd7Uaj+SF1xZUSU+nPM5aDNBVtnw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -738,9 +738,9 @@ globals@^12.1.0:
     type-fest "^0.8.1"
 
 globals@^13.6.0:
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.6.0.tgz#d77138e53738567bb96a3916ff6f6b487af20ef7"
-  integrity sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.7.0.tgz#aed3bcefd80ad3ec0f0be2cf0c895110c0591795"
+  integrity sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==
   dependencies:
     type-fest "^0.20.2"
 
@@ -1260,10 +1260,10 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.41.2:
-  version "2.41.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.2.tgz#b7db5cb7c21c2d524e8b26ef39c7e9808a290c7e"
-  integrity sha512-6u8fJJXJx6fmvKrAC9DHYZgONvSkz8S9b/VFBjoQ6dkKdHyPpPbpqiNl2Bao9XBzDHpq672X6sGZ9G1ZBqAHMg==
+rollup@^2.42.3:
+  version "2.42.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.42.3.tgz#7935d7bc8687faa5743432e207d761aa31fe6fee"
+  integrity sha512-JjaT9WaUS5vmjy6xUrnPOskjkQg2cN4WSACNCwbOvBz8VDmbiKVdmTFUoMPRqTud0tsex8Xy9/boLbDW9HKD1w==
   optionalDependencies:
     fsevents "~2.3.1"
 
@@ -1456,9 +1456,9 @@ tape@^5.2.2:
     through "^2.3.8"
 
 terser@^5.0.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.0.tgz#138cdf21c5e3100b1b3ddfddf720962f88badcd2"
-  integrity sha512-vyqLMoqadC1uR0vywqOZzriDYzgEkNJFK4q9GeyOBHIbiECHiWLKcWfbQWAUaPfxkjDhapSlZB9f7fkMrvkVjA==
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.1.tgz#a48eeac5300c0a09b36854bf90d9c26fb201973c"
+  integrity sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.7.2"


### PR DESCRIPTION
Changes from [v4.0.0](https://github.com/uwdata/arquero/releases/tag/v4.0.0):

- Add `grouped` option for `table.objects()` method to export nested data. (thanks @lsh!)
- Add `shuffle` option for the `sample()` verb. All sampled tables are  now shuffled by default.
- Add `op.parse_json` and `op.to_json` functions for wrangling JSON string data.
- Add `op.map_agg` and `op.entries_agg` aggregate functions, similar to the existing `op.object_agg`.
- Add `columns` option for `table.objects` and `table.print` output.
- Update `table.get(column, row)` to default to row index `0` if `row` is unspecified.
- Update aggregate value collector to avoid unnecessary array copies.
- Fix table expression code generation for computed object keys (`{['a'+'b']: 'c'}`).
- Fix `aq.table()` bug with `Map` input.