### PR TITLE
Add columns option for objects/print output.

### DIFF
--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -388,6 +388,7 @@ Returns an array of objects representing table rows. A new set of objects will b
 * *options*: Options for row generation:
   * *limit*: The maximum number of objects to create (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
+  * *columns*: An ordered set of columns to include. The input may consist of: column name strings, column integer indices, objects with current column names as keys and new column names as values (for renaming), or a selection helper function such as [all](#all), [not](#not), or [range](#range)).
 
 *Examples*
 
@@ -422,6 +423,7 @@ Print the contents of this table using the `console.table()` method.
 * *options*: Options for printing. If number-valued, specifies the row limit (equivalent to `{ limit: value }`).
   * *limit*: The maximum number of rows to print (default `10`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
+  * *columns*: An ordered set of columns to print. The input may consist of: column name strings, column integer indices, objects with current column names as keys and new column names as values (for renaming), or a selection helper function such as [all](#all), [not](#not), or [range](#range)).
 
 *Examples*
 

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -8,6 +8,7 @@ import toCSV from '../format/to-csv';
 import toHTML from '../format/to-html';
 import toJSON from '../format/to-json';
 import toMarkdown from '../format/to-markdown';
+import resolve, { all } from '../helpers/selection';
 import arrayType from '../util/array-type';
 import error from '../util/error';
 import mapObject from '../util/map-object';
@@ -163,7 +164,8 @@ export default class ColumnTable extends Table {
    * @return {object[]} An array of row objects.
    */
   objects(options = {}) {
-    const create = rowObjectBuilder(this);
+    const names = resolve(this, options.columns || all());
+    const create = rowObjectBuilder(this, names);
     const tuples = [];
     this.scan(row => {
       tuples.push(create(row));

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -19,11 +19,13 @@ Object.assign(ColumnTable.prototype, verbs);
  * @example table({ colA: ['a', 'b', 'c'], colB: [3, 4, 5] })
  */
 export function table(columns, names) {
-  const cols = entries(columns);
-  return new ColumnTable(
-    cols.reduce((obj, [k, v]) => (obj[k] = v, obj), {}),
-    names || cols.map(c => c[0])
-  );
+  const data = {};
+  const keys = [];
+  for (const [key, value] of entries(columns)) {
+    data[key] = value;
+    keys.push(key);
+  }
+  return new ColumnTable(data, names || keys);
 }
 
 /**

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -525,4 +525,9 @@ export default class Table extends Transformable {
  * @typedef {object} ObjectsOptions
  * @property {number} [limit=Infinity] The maximum number of objects to create.
  * @property {number} [offset=0] The row offset indicating how many initial rows to skip.
+ * @property {import('../table/transformable').Select} columns
+ *  An ordered set of columns to include. The input may consist of column name
+ *  strings, column integer indices, objects with current column names as keys
+ *  and new column names as values (for renaming), or selection helper
+ *  functions such as {@link all}, {@link not}, or {@link range}.
  */

--- a/src/util/row-object-builder.js
+++ b/src/util/row-object-builder.js
@@ -1,10 +1,17 @@
+import entries from './entries';
+import isArray from './is-array';
 import unroll from './unroll';
 
 export default function(table, names) {
-  names = names || table.columnNames();
-  return unroll(
-    'row',
-    '({' + names.map((_, i) => `${JSON.stringify(_)}:_${i}.get(row)`) + '})',
-    names.map(name => table.column(name))
-  );
+  const props = [];
+  const cols = [];
+  let i = -1;
+
+  for (const entry of entries(names || table.columnNames())) {
+    const [name, key] = isArray(entry) ? entry : [entry, entry];
+    props.push(`${JSON.stringify(key)}:_${++i}.get(row)`);
+    cols.push(table.column(name));
+  }
+
+  return unroll('row', '({' + props + '})', cols);
 }

--- a/test/table/column-table-test.js
+++ b/test/table/column-table-test.js
@@ -1,5 +1,6 @@
 import tape from 'tape';
 import tableEqual from '../table-equal';
+import { not } from '../../src/helpers/selection';
 import BitSet from '../../src/table/bit-set';
 import ColumnTable from '../../src/table/column-table';
 
@@ -138,6 +139,18 @@ tape('ColumnTable supports object output', t => {
     dt.objects({ limit: 3 }),
     output.slice(0, 3),
     'object data with limit'
+  );
+
+  t.deepEqual(
+    dt.objects({ columns: not('v') }),
+    output.map(d => ({ u: d.u })),
+    'object data with column selection'
+  );
+
+  t.deepEqual(
+    dt.objects({ columns: { u: 'a', v: 'b'} }),
+    output.map(d => ({ a: d.u, b: d.v })),
+    'object data with renaming column selection'
   );
 
   t.end();


### PR DESCRIPTION
- Add columns option for `table.objects` and `table.print` output.
- Fix `aq.table()` bug with `Map` inputs