### PR TITLE
Add shuffle option for sample.

### DIFF
--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -194,6 +194,7 @@ Generate a table from a random sample of rows. If the table is grouped, perform 
 * *size*: The number of samples to draw per group. If number-valued, the same sample size is used for each group. If function-valued, the input should be an aggregate table expression compatible with [rollup](#rollup).
 * *options*: An options object:
   * *replace*: Boolean flag (default `false`) to sample with replacement.
+  * *shuffle*: Boolean flag (default `true`) to ensure randomly ordered rows.
   * *weight*: Column values to use as weights for sampling. Rows will be sampled with probability proportional to their relative weight. The input should be a column name string or a table expression compatible with [derive](#derive).
 
 *Examples*

--- a/src/engine/sample.js
+++ b/src/engine/sample.js
@@ -1,7 +1,8 @@
 import sample from '../util/sample';
+import _shuffle from '../util/shuffle';
 
 export default function(table, size, weight, options = {}) {
-  const replace = !!options.replace;
+  const { replace, shuffle } = options;
   const parts = table.partitions(false);
 
   let total = 0;
@@ -26,6 +27,12 @@ export default function(table, size, weight, options = {}) {
       sample(buf, replace, idx, weight);
     }
   });
+
+  if (shuffle !== false && (parts.length > 1 || !replace)) {
+    // sampling with replacement methods shuffle, so in
+    // that case a single partition is already good to go
+    _shuffle(samples);
+  }
 
   return table.reify(samples);
 }

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -865,6 +865,7 @@ export default class Transformable {
  * Options for sample transformations.
  * @typedef {object} SampleOptions
  * @property {boolean} [replace=false] Flag for sampling with replacement.
+ * @property {boolean} [shuffle=true] Flag to ensure randomly ordered rows.
  * @property {string|TableExpr} [weight] Column values to use as weights
  *  for sampling. Rows will be sampled with probability proportional to
  *  their relative weight. The input should be a column name string or

--- a/src/util/shuffle.js
+++ b/src/util/shuffle.js
@@ -1,0 +1,14 @@
+import { random } from './random';
+
+export default function(array, lo = 0, hi = array.length) {
+  let n = hi - (lo = +lo);
+
+  while (n) {
+    const i = random() * n-- | 0;
+    const v = array[n + lo];
+    array[n + lo] = array[i + lo];
+    array[i + lo] = v;
+  }
+
+  return array;
+}

--- a/test/query/query-test.js
+++ b/test/query/query-test.js
@@ -521,7 +521,7 @@ tape('Query evaluates sample verbs', t => {
     Query.from(
       new Query([sample(2, { replace: true })]).toObject()
     ).evaluate(dt),
-    { foo: [ 2, 2 ], bar: [ 0, 0 ] },
+    { foo: [ 3, 0 ], bar: [ 0, 1 ] },
     'sample query result, replace'
   );
 
@@ -530,7 +530,7 @@ tape('Query evaluates sample verbs', t => {
     Query.from(
       new Query([sample(2, { weight: 'foo' })]).toObject()
     ).evaluate(dt),
-    { foo: [ 3, 2 ], bar: [ 0, 0 ] },
+    { foo: [ 2, 3 ], bar: [ 0, 0 ] },
     'sample query result, weight column name'
   );
 
@@ -539,7 +539,7 @@ tape('Query evaluates sample verbs', t => {
     Query.from(
       new Query([sample(2, { weight: d => d.foo })]).toObject()
     ).evaluate(dt),
-    { foo: [ 3, 1 ], bar: [ 0, 1 ] },
+    { foo: [ 3, 2 ], bar: [ 0, 0 ] },
     'sample query result, weight table expression'
   );
 


### PR DESCRIPTION
- Add `shuffle` option (default `true`) for the `sample()` verb.

Closes #127.