### PR TITLE
Optimize semijoin and antijoin performance.

### DIFF
--- a/src/engine/join-filter.js
+++ b/src/engine/join-filter.js
@@ -1,7 +1,33 @@
+import { singleRowLookup } from './join/lookup';
 import BitSet from '../table/bit-set';
+import isArray from '../util/is-array';
 
 export default function(tableL, tableR, predicate, options = {}) {
+  // calculate semi-join filter mask
   const filter = new BitSet(tableL.totalRows());
+  const join = isArray(predicate) ? hashSemiJoin : loopSemiJoin;
+  join(filter, tableL, tableR, predicate);
+
+  // if anti-join, negate the filter
+  if (options.anti) {
+    filter.not().and(tableL.mask());
+  }
+
+  return tableL.create({ filter });
+}
+
+function hashSemiJoin(filter, tableL, tableR, [keyL, keyR]) {
+  // build lookup table
+  const lut = singleRowLookup(tableR, keyR);
+
+  // scan table, update filter with matches
+  tableL.scan((rowL, data) => {
+    const rowR = lut.get(keyL(rowL, data));
+    if (rowR >= 0) filter.set(rowL);
+  });
+}
+
+function loopSemiJoin(filter, tableL, tableR, predicate) {
   const nL = tableL.numRows();
   const nR = tableR.numRows();
   const dataL = tableL.data();
@@ -31,11 +57,44 @@ export default function(tableL, tableR, predicate, options = {}) {
       }
     }
   }
-
-  // if anti-join, negate the filter
-  if (options.anti) {
-    filter.not().and(tableL.mask());
-  }
-
-  return tableL.create({ filter });
 }
+
+// export default function(tableL, tableR, predicate, options = {}) {
+//   const filter = new BitSet(tableL.totalRows());
+//   const nL = tableL.numRows();
+//   const nR = tableR.numRows();
+//   const dataL = tableL.data();
+//   const dataR = tableR.data();
+
+//   if (tableL.isFiltered() || tableR.isFiltered()) {
+//     // use indices as at least one table is filtered
+//     const idxL = tableL.indices(false);
+//     const idxR = tableR.indices(false);
+//     for (let i = 0; i < nL; ++i) {
+//       const rowL = idxL[i];
+//       for (let j = 0; j < nR; ++j) {
+//         if (predicate(rowL, dataL, idxR[j], dataR)) {
+//           filter.set(rowL);
+//           break;
+//         }
+//       }
+//     }
+//   } else {
+//     // no filters, enumerate row indices directly
+//     for (let i = 0; i < nL; ++i) {
+//       for (let j = 0; j < nR; ++j) {
+//         if (predicate(i, dataL, j, dataR)) {
+//           filter.set(i);
+//           break;
+//         }
+//       }
+//     }
+//   }
+
+//   // if anti-join, negate the filter
+//   if (options.anti) {
+//     filter.not().and(tableL.mask());
+//   }
+
+//   return tableL.create({ filter });
+// }

--- a/src/engine/join/lookup.js
+++ b/src/engine/join/lookup.js
@@ -1,0 +1,25 @@
+export function singleRowLookup(table, hash) {
+  const lut = new Map();
+  table.scan((row, data) => {
+    const key = hash(row, data);
+    if (key != null && key === key) {
+      lut.set(key, row);
+    }
+  });
+  return lut;
+}
+
+export function multiRowLookup(idx, data, hash) {
+  const lut = new Map();
+  const n = idx.length;
+  for (let i = 0; i < n; ++i) {
+    const row = idx[i];
+    const key = hash(row, data);
+    if (key != null && key === key) {
+      lut.has(key)
+        ? lut.get(key).push(row)
+        : lut.set(key, [row]);
+    }
+  }
+  return lut;
+}

--- a/src/engine/lookup.js
+++ b/src/engine/lookup.js
@@ -1,46 +1,33 @@
+import { singleRowLookup } from './join/lookup';
 import { aggregateGet } from './reduce/util';
 import columnSet from '../table/column-set';
 import NULL from '../util/null';
+import concat from '../util/concat';
+import unroll from '../util/unroll';
 
 export default function(tableL, tableR, [keyL, keyR], { names, exprs, ops }) {
   // instantiate output data
   const cols = columnSet(tableL);
   const total = tableL.totalRows();
-  names.forEach(name => cols.add(name, Array(total)));
+  names.forEach(name => cols.add(name, Array(total).fill(NULL)));
 
   // build lookup table
-  const lut = new Map();
-  tableR.scan((row, data) => {
-    const key = keyR(row, data);
-    if (key != null && key === key) {
-      lut.set(keyR(row, data), row);
-    }
-  });
+  const lut = singleRowLookup(tableR, keyR);
 
-  // find matching rows
-  const rowL = new Int32Array(tableL.numRows());
-  const rowR = new Int32Array(tableL.numRows());
-  let m = 0;
+  // generate setter function for lookup match
+  const set = unroll(
+    ['lr', 'rr', 'data'],
+    '{' + concat(names, (_, i) => `_[${i}][lr] = $[${i}](rr, data);`) + '}',
+    names.map(name => cols.data[name]),
+    aggregateGet(tableR, ops, exprs)
+  );
+
+  // find matching rows, set values on match
+  const dataR = tableR.data();
   tableL.scan((lrow, data) => {
     const rrow = lut.get(keyL(lrow, data));
-    rowL[m] = lrow;
-    rowR[m] = rrow == null ? -1 : rrow;
-    ++m;
+    if (rrow >= 0) set(lrow, rrow, dataR);
   });
-
-  // output values for matching rows
-  const dataR = tableR.data();
-  const get = aggregateGet(tableR, ops, exprs);
-  const n = get.length;
-
-  for (let i = 0; i < n; ++i) {
-    const column = cols.data[names[i]];
-    const getter = get[i];
-    for (let j = 0; j < m; ++j) {
-      const rrow = rowR[j];
-      column[rowL[j]] = rrow >= 0 ? getter(rrow, dataR) : NULL;
-    }
-  }
 
   return tableL.create(cols);
 }

--- a/src/verbs/join-filter.js
+++ b/src/verbs/join-filter.js
@@ -1,25 +1,15 @@
 import _join_filter from '../engine/join-filter';
+import { inferKeys, keyPredicate } from './util/join-keys';
 import parse from '../expression/parse';
-import { inferKeys } from './join';
-import parseKey from './util/parse-key';
 import isArray from '../util/is-array';
+import toArray from '../util/to-array';
 
 export default function(tableL, tableR, on, options) {
   on = inferKeys(tableL, tableR, on);
-  on = isArray(on)
-    ? toPredicate(
-        parseKey('join', tableL, on[0]),
-        parseKey('join', tableR, on[1])
-      )
+
+  const predicate = isArray(on)
+    ? keyPredicate(tableL, tableR, ...on.map(toArray))
     : parse({ on }, { join: [tableL, tableR] }).exprs[0];
 
-  return _join_filter(tableL, tableR, on, options);
-}
-
-function toPredicate(keyL, keyR) {
-  return (rowL, dataL, rowR, dataR) => {
-    const kl = keyL(rowL, dataL);
-    const kr = keyR(rowR, dataR);
-    return kl === kr && kl != null && kr != null;
-  };
+  return _join_filter(tableL, tableR, predicate, options);
 }

--- a/src/verbs/lookup.js
+++ b/src/verbs/lookup.js
@@ -1,5 +1,5 @@
 import _lookup from '../engine/lookup';
-import { inferKeys } from './join';
+import { inferKeys } from './util/join-keys';
 import parseKey from './util/parse-key';
 import parseValues from './util/parse';
 

--- a/src/verbs/util/join-keys.js
+++ b/src/verbs/util/join-keys.js
@@ -1,0 +1,30 @@
+import parseKey from './parse-key';
+import error from '../../util/error';
+import intersect from '../../util/intersect';
+import isArray from '../../util/is-array';
+import isString from '../../util/is-string';
+
+export function inferKeys(tableL, tableR, on) {
+  if (!on) {
+    // perform natural join if join condition not provided
+    const isect = intersect(tableL.columnNames(), tableR.columnNames());
+    if (!isect.length) error('Natural join requires shared column names.');
+    on = [isect, isect];
+  } else if (isString(on)) {
+    on = [on, on];
+  } else if (isArray(on) && on.length === 1) {
+    on = [on[0], on[0]];
+  }
+
+  return on;
+}
+
+export function keyPredicate(tableL, tableR, onL, onR) {
+  if (onL.length !== onR.length) {
+    error('Mismatched number of join keys');
+  }
+  return [
+    parseKey('join', tableL, onL),
+    parseKey('join', tableR, onR)
+  ];
+}

--- a/test/verbs/join-filter-test.js
+++ b/test/verbs/join-filter-test.js
@@ -32,13 +32,23 @@ tape('semijoin uses natural join criteria', t => {
 
 tape('semijoin filters left table to matching rows', t => {
   const [tl, tr] = joinTables();
-  const tj = tl.semijoin(tr, (a, b) => a.k === b.u);
-
-  tableEqual(t, tj, {
+  const output = {
     k: [ 'a', 'b', 'b' ],
     x: [ 1, 2, 3 ],
     y: [ 9, 8, 7 ]
-  }, 'semijoin data');
+  };
+
+  tableEqual(t,
+    tl.semijoin(tr, ['k', 'u']),
+    output,
+    'semijoin data, with keys'
+  );
+
+  tableEqual(t,
+    tl.semijoin(tr, (a, b) => a.k === b.u),
+    output,
+    'semijoin data, with predicate'
+  );
 
   t.end();
 });
@@ -59,13 +69,23 @@ tape('antijoin uses natural join criteria', t => {
 
 tape('antijoin filters left table to non-matching rows', t => {
   const [tl, tr] = joinTables();
-  const tj = tl.antijoin(tr, ['k', 'u']);
-
-  tableEqual(t, tj, {
+  const output = {
     k: [ 'c' ],
     x: [ 4 ],
     y: [ 6 ]
-  }, 'antijoin data');
+  };
+
+  tableEqual(t,
+    tl.antijoin(tr, ['k', 'u']),
+    output,
+    'antijoin data, with keys'
+  );
+
+  tableEqual(t,
+    tl.antijoin(tr, (a, b) => a.k === b.u),
+    output,
+    'antijoin data, with predicate'
+  );
 
   t.end();
 });


### PR DESCRIPTION
- Add hash-join support to optimize `semijoin()` and `antijoin()`.
- Refactor join utilities.

Close #136.