### PR TITLE
Add bins step option.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -430,6 +430,7 @@ Generate a table expression that performs uniform binning of number values. The 
   * *minstep*: The minimum step size between bins.
   * *nice*: Boolean flag (default `true`) indicating if bins should snap to "nice" human-friendly values such as multiples of ten.
   * *offset*: Step offset for bin boundaries. The default (`0`) floors to the lower bin boundary. A value of `1` snaps one step higher to the upper bin boundary, and so on.
+  * *step*: The exact step size to use between bins. If specified, the *maxbins* and *minstep* options are ignored.
 
  *Examples*
 

--- a/docs/api/op.md
+++ b/docs/api/op.md
@@ -918,6 +918,7 @@ Aggregate function for calculating a binning scheme in terms of the minimum bin 
 * *maxbins*: The maximum number of allowed bins (default `15`).
 * *nice*: Boolean flag (default `true`) indicating if the bin min and max should snap to "nice" human-friendly values such as multiples of 10.
 * *minstep*: The minimum allowed step size between bins.
+* *step*: The exact step size to use between bins. If specified, the *maxbins* and *minstep* arguments are ignored.
 
 <hr/><a id="count" href="#count">#</a>
 <em>op</em>.<b>count</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/op/aggregate-functions.js)

--- a/src/helpers/bin.js
+++ b/src/helpers/bin.js
@@ -3,6 +3,8 @@
  * @typedef {object} BinOptions
  * @property {number} [maxbins] The maximum number of bins.
  * @property {number} [minstep] The minimum step size between bins.
+ * @property {number} [step] The exact step size to use between bins.
+ *  If specified, the maxbins and minstep options are ignored.
  * @property {boolean} [nice=true] Flag indicating if bins should
  *  snap to "nice" human-friendly values such as multiples of ten.
  * @property {number} [offset=0] Step offset for bin boundaries.
@@ -20,12 +22,13 @@
  * @example bin('colA', { maxbins: 20 })
  */
 export default function(name, options = {}) {
-  const field = `d[${JSON.stringify(name)}]`,
-        { maxbins, nice, minstep, offset } = options,
-        args = [maxbins, nice, minstep];
+  const field = `d[${JSON.stringify(name)}]`;
+  const { maxbins, nice, minstep, step, offset } = options;
+  const args = [maxbins, nice, minstep, step];
 
   let n = args.length;
   while (n && args[--n] == null) args.pop();
-  const bins = `op.bins(${field}${args.length ? ', ' + args.join(', ') : ''})`;
-  return `d => op.bin(${field}, ...${bins}, ${offset || 0})`;
+  const a = args.length ? ', ' + args.map(a => a + '').join(', ') : '';
+
+  return `d => op.bin(${field}, ...op.bins(${field}${a}), ${offset || 0})`;
 }

--- a/src/op/aggregate-functions.js
+++ b/src/op/aggregate-functions.js
@@ -384,10 +384,10 @@ export default {
 
   /** @type {AggregateDef} */
   bins: {
-    create: (maxbins, nice, minstep) => initOp({
-      value: s => bins(s.min, s.max, maxbins, nice, minstep)
+    create: (maxbins, nice, minstep, step) => initOp({
+      value: s => bins(s.min, s.max, maxbins, nice, minstep, step)
     }),
-    param: [1, 3],
+    param: [1, 4],
     req: ['min', 'max']
   }
 };

--- a/src/op/op-api.js
+++ b/src/op/op-api.js
@@ -219,6 +219,8 @@ export default {
    * @param {boolean} [nice=true] Flag indicating if the bin min and max
    *  should snap to "nice" human-friendly values.
    * @param {number} [minstep] The minimum allowed step size between bins.
+   * @param {number} [step] The exact step size to use between bins.
+   *  If specified, the maxbins and minstep arguments are ignored.
    * @return {[number, number, number]} The bin min, max, and step values.
    */
   bins: (field, maxbins, nice, minstep) =>

--- a/src/util/bins.js
+++ b/src/util/bins.js
@@ -1,26 +1,29 @@
-export default function(min, max, maxbins = 15, nice = true, minstep = 0) {
-  const div = [5, 2];
+export default function(min, max, maxbins = 15, nice = true, minstep = 0, step) {
   const base = 10;
   const logb = Math.LN10;
-  const level = Math.ceil(Math.log(maxbins) / logb);
-  const span = (max - min) || Math.abs(min) || 1;
 
-  let step = Math.max(
-    minstep,
-    Math.pow(base, Math.round(Math.log(span) / logb) - level)
-  );
+  if (step == null) {
+    const level = Math.ceil(Math.log(maxbins) / logb);
+    const span = (max - min) || Math.abs(min) || 1;
+    const div = [5, 2];
 
-  // increase step size if too many bins
-  while (Math.ceil(span / step) > maxbins) {
-    step *= base;
-  }
+    step = Math.max(
+      minstep,
+      Math.pow(base, Math.round(Math.log(span) / logb) - level)
+    );
 
-  // decrease step size if it stays within maxbins
-  const n = div.length;
-  for (let i = 0; i < n; ++i) {
-    const v = step / div[i];
-    if (v >= minstep && span / v <= maxbins) {
-      step = v;
+    // increase step size if too many bins
+    while (Math.ceil(span / step) > maxbins) {
+      step *= base;
+    }
+
+    // decrease step size if it stays within maxbins
+    const n = div.length;
+    for (let i = 0; i < n; ++i) {
+      const v = step / div[i];
+      if (v >= minstep && span / v <= maxbins) {
+        step = v;
+      }
     }
   }
 

--- a/test/verbs/rollup-test.js
+++ b/test/verbs/rollup-test.js
@@ -192,7 +192,15 @@ tape('rollup supports histogram', t => {
       b1: bin('x', { maxbins: 20, offset: 1 })
     })
     .count();
-  tableEqual(t,  ht, result, 'histogram from bin helper');
+  tableEqual(t,  ht, result, 'histogram from bin helper, maxbins');
+
+  const st = table(data)
+    .groupby({
+      b0: bin('x', { step: 0.5 }),
+      b1: bin('x', { step: 0.5, offset: 1 })
+    })
+    .count();
+  tableEqual(t,  st, result, 'histogram from bin helper, step');
 
   t.end();
 });


### PR DESCRIPTION
Updates bin determination functions to additionally support an explicit step size.

* Add `step` option to `aq.bin` helper function.
* Add `step` argument to `op.bins` aggregate function.

Close #145.