### PR TITLE
Add column value extraction methods.

### DIFF
--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -14,7 +14,7 @@ title: Table \| Arquero API Reference
   * [column](#column), [columnAt](#columnAt), [columnArray](#columnArray)
   * [columnIndex](#columnIndex), [columnName](#columnName), [columnNames](#columnNames)
   * [assign](#assign)
-* [Table Values](#values)
+* [Table Values](#table-values)
   * [data](#data), [get](#get), [getter](#getter), [values](#values)
   * [indices](#indices), [partitions](#partitions), [scan](#scan)
 * [Table Output](#output)
@@ -304,7 +304,7 @@ t1.assign(t2); // { a: [1, 2], b: [7, 8], c: [5, 6] }
 
 <br/>
 
-## <a id="values">Table Values</a>
+## <a id="table-values">Table Values</a>
 
 <hr/><a id="data" href="#data">#</a>
 <em>table</em>.<b>data</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -15,7 +15,7 @@ title: Table \| Arquero API Reference
   * [columnIndex](#columnIndex), [columnName](#columnName), [columnNames](#columnNames)
   * [assign](#assign)
 * [Table Values](#values)
-  * [data](#data), [get](#get), [getter](#getter)
+  * [data](#data), [get](#get), [getter](#getter), [values](#values)
   * [indices](#indices), [partitions](#partitions), [scan](#scan)
 * [Table Output](#output)
   * [objects](#objects), [object](#object), [Symbol.iterator](#@@iterator)
@@ -339,6 +339,8 @@ dt.get('a', 2) // 1
 
 Returns an accessor ("getter") function for a column. The returned function takes a row index as its single argument and returns the corresponding column value. Row indices are relative to any filtering and ordering criteria, not the internal data layout.
 
+* *name*: The column name.
+
 *Examples*
 
 ```js
@@ -355,7 +357,25 @@ get(0) // 3
 get(2) // 1
 ```
 
+<hr/><a id="values" href="#values">#</a>
+<em>table</em>.<b>values</b>(<i>name</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
+
+Returns an iterator over values in the column with the given *name*. The iterator returned by this method respects any table filter or orderby criteria.
+
 * *name*: The column name.
+
+*Examples*
+
+```js
+for (const value of table.values('colA')) {
+  // do something with ordered values from column A
+}
+```
+
+```js
+// slightly less efficient version of table.columnArray('colA')
+const colValues = Array.from(table.values('colA'));
+```
 
 <hr/><a id="indices" href="#indices">#</a>
 <em>table</em>.<b>indices</b>([<i>order</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -15,7 +15,8 @@ title: Table \| Arquero API Reference
   * [columnIndex](#columnIndex), [columnName](#columnName), [columnNames](#columnNames)
   * [assign](#assign)
 * [Table Values](#table-values)
-  * [data](#data), [get](#get), [getter](#getter), [values](#values)
+  * [array](#array), [values](#values)
+  * [data](#data), [get](#get), [getter](#getter)
   * [indices](#indices), [partitions](#partitions), [scan](#scan)
 * [Table Output](#output)
   * [objects](#objects), [object](#object), [Symbol.iterator](#@@iterator)
@@ -217,30 +218,14 @@ dt.columnAt(1).get(1) // 5
 ```
 
 <hr/><a id="columnArray" href="#columnArray">#</a>
-<em>table</em>.<b>columnArray</b>(<i>name</i>[, <i>arrayConstructor</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
+<em>table</em>.<b>columnArray</b>(<i>name</i>[, <i>constructor</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
-Get an array of values contained in the column with the given *name*. Unlike direct access through the table [column](#column) method, the array returned by this method respects any table filter or orderby criteria. By default, a standard [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) is returned; use the *arrayConstructor* argument to specify a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
+_This method is a deprecated alias for the table [array()](#array) method. Please use [array()](#array) instead._
+
+Get an array of values contained in the column with the given *name*. Unlike direct access through the table [column](#column) method, the array returned by this method respects any table filter or orderby criteria. By default, a standard [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) is returned; use the *constructor* argument to specify a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
 
 * *name*: The column name.
-* *arrayConstructor*: An optional array constructor (default [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array)) to use to instantiate the output array. Note that errors or truncated values may occur when assigning to a typed array with an incompatible type.
-
-*Examples*
-
-```js
-aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
-  .columnArray('b'); // [ 4, 5, 6 ]
-```
-
-```js
-aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
-  .filter(d => d.a > 1)
-  .columnArray('b'); // [ 5, 6 ]
-```
-
-```js
-aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
-  .columnArray('b', Int32Array); // Int32Array.of(4, 5, 6)
-```
+* *constructor*: An optional array constructor (default [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array)) to use to instantiate the output array. Note that errors or truncated values may occur when assigning to a typed array with an incompatible type.
 
 <hr/><a id="columnIndex" href="#columnIndex">#</a>
 <em>table</em>.<b>columnIndex</b>(<i>name</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
@@ -306,6 +291,52 @@ t1.assign(t2); // { a: [1, 2], b: [7, 8], c: [5, 6] }
 
 ## <a id="table-values">Table Values</a>
 
+<hr/><a id="array" href="#array">#</a>
+<em>table</em>.<b>array</b>(<i>name</i>[, <i>constructor</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
+
+Get an array of values contained in the column with the given *name*. Unlike direct access through the table [column](#column) method, the array returned by this method respects any table filter or orderby criteria. By default, a standard [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) is returned; use the *constructor* argument to specify a [typed array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
+
+* *name*: The column name.
+* *constructor*: An optional array constructor (default [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Array)) to use to instantiate the output array. Note that errors or truncated values may occur when assigning to a typed array with an incompatible type.
+
+*Examples*
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .array('b'); // [ 4, 5, 6 ]
+```
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .filter(d => d.a > 1)
+  .array('b'); // [ 5, 6 ]
+```
+
+```js
+aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
+  .array('b', Int32Array); // Int32Array.of(4, 5, 6)
+```
+
+<hr/><a id="values" href="#values">#</a>
+<em>table</em>.<b>values</b>(<i>name</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
+
+Returns an iterator over values in the column with the given *name*. The iterator returned by this method respects any table filter or orderby criteria.
+
+* *name*: The column name.
+
+*Examples*
+
+```js
+for (const value of table.values('colA')) {
+  // do something with ordered values from column A
+}
+```
+
+```js
+// slightly less efficient version of table.columnArray('colA')
+const colValues = Array.from(table.values('colA'));
+```
+
 <hr/><a id="data" href="#data">#</a>
 <em>table</em>.<b>data</b>() · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
 
@@ -355,26 +386,6 @@ const dt = aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
   .getter('a');
 get(0) // 3
 get(2) // 1
-```
-
-<hr/><a id="values" href="#values">#</a>
-<em>table</em>.<b>values</b>(<i>name</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/table.js)
-
-Returns an iterator over values in the column with the given *name*. The iterator returned by this method respects any table filter or orderby criteria.
-
-* *name*: The column name.
-
-*Examples*
-
-```js
-for (const value of table.values('colA')) {
-  // do something with ordered values from column A
-}
-```
-
-```js
-// slightly less efficient version of table.columnArray('colA')
-const colValues = Array.from(table.values('colA'));
 ```
 
 <hr/><a id="indices" href="#indices">#</a>

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -120,13 +120,13 @@ export default class ColumnTable extends Table {
    * Get an array of values contained in a column. The resulting array
    * respects any table filter or orderby criteria.
    * @param {string} name The column name.
-   * @param {ArrayConstructor|import('./table').TypedArrayConstructor} [arrayConstructor=Array]
+   * @param {ArrayConstructor|import('./table').TypedArrayConstructor} [constructor=Array]
    *  The array constructor for instantiating the output array.
    * @return {import('./table').DataValue[]|import('./table).TypedArray} The array of column values.
    */
-  columnArray(name, arrayConstructor = Array) {
+  array(name, constructor = Array) {
     const column = this.column(name);
-    const array = new arrayConstructor(this.numRows());
+    const array = new constructor(this.numRows());
     let idx = -1;
     this.scan(row => array[++idx] = column.get(row), true);
     return array;

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -197,6 +197,18 @@ export default class Table extends Transformable {
   }
 
   /**
+   * Returns an iterator over column values.
+   * @return {Iterator<object>} An iterator over row objects.
+   */
+  *values(name) {
+    const get = this.getter(name);
+    const n = this.numRows();
+    for (let i = 0; i < n; ++i) {
+      yield get(i);
+    }
+  }
+
+  /**
    * Get the value for the given column and row.
    * @param {string} name The column name.
    * @param {number} [row=0] The row index, defaults to zero if not specified.

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -185,14 +185,27 @@ export default class Table extends Transformable {
   }
 
   /**
-   * Get an array of values contained in a column. The resulting array
-   * respects any table filter or orderby criteria.
+   * Deprecated alias for the table array() method: use table.array()
+   * instead. Get an array of values contained in a column. The resulting
+   * array respects any table filter or orderby criteria.
    * @param {string} name The column name.
-   * @param {ArrayConstructor|TypedArrayConstructor} [arrayConstructor=Array]
+   * @param {ArrayConstructor|TypedArrayConstructor} [constructor=Array]
    *  The array constructor for instantiating the output array.
    * @return {DataValue[]|TypedArray} The array of column values.
    */
-  columnArray(name, arrayConstructor) { // eslint-disable-line no-unused-vars
+  columnArray(name, constructor) {
+    return this.array(name, constructor);
+  }
+
+  /**
+   * Get an array of values contained in a column. The resulting array
+   * respects any table filter or orderby criteria.
+   * @param {string} name The column name.
+   * @param {ArrayConstructor|TypedArrayConstructor} [constructor=Array]
+   *  The array constructor for instantiating the output array.
+   * @return {DataValue[]|TypedArray} The array of column values.
+   */
+  array(name, constructor) { // eslint-disable-line no-unused-vars
     error('Not implemented');
   }
 

--- a/test/table/column-table-test.js
+++ b/test/table/column-table-test.js
@@ -119,6 +119,64 @@ tape('ColumnTable memoizes indices', t => {
   t.end();
 });
 
+tape('ColumnTable supports values output', t => {
+  const dt = new ColumnTable({
+      u: ['a', 'a', 'a', 'b', 'b'],
+      v: [2, 1, 4, 5, 3]
+    })
+    .filter(d => d.v > 1)
+    .orderby('v');
+
+  t.deepEqual(
+    Array.from(dt.values('u')),
+    ['a', 'b', 'a', 'b'],
+    'values, strings'
+  );
+
+  t.deepEqual(
+    Array.from(dt.values('v')),
+    [2, 3, 4, 5],
+    'values, numbers'
+  );
+
+  t.deepEqual(
+    Int32Array.from(dt.values('v')),
+    Int32Array.of(2, 3, 4, 5),
+    'values, typed array'
+  );
+
+  t.end();
+});
+
+tape('ColumnTable supports column array output', t => {
+  const dt = new ColumnTable({
+      u: ['a', 'a', 'a', 'b', 'b'],
+      v: [2, 1, 4, 5, 3]
+    })
+    .filter(d => d.v > 1)
+    .orderby('v');
+
+  t.deepEqual(
+    dt.columnArray('u'),
+    ['a', 'b', 'a', 'b'],
+    'column array, strings'
+  );
+
+  t.deepEqual(
+    dt.columnArray('v'),
+    [2, 3, 4, 5],
+    'column array, numbers'
+  );
+
+  t.deepEqual(
+    dt.columnArray('v', Int32Array),
+    Int32Array.of(2, 3, 4, 5),
+    'column array, typed array'
+  );
+
+  t.end();
+});
+
 tape('ColumnTable supports object output', t => {
   const output = [
     { u: 'a', v: 1 },
@@ -170,35 +228,6 @@ tape('ColumnTable supports object output', t => {
     dt.object(1),
     output[1],
     'single object, explicit row'
-  );
-
-  t.end();
-});
-
-tape('ColumnTable supports column array output', t => {
-  const dt = new ColumnTable({
-      u: ['a', 'a', 'a', 'b', 'b'],
-      v: [2, 1, 4, 5, 3]
-    })
-    .filter(d => d.v > 1)
-    .orderby('v');
-
-  t.deepEqual(
-    dt.columnArray('u'),
-    ['a', 'b', 'a', 'b'],
-    'column array, strings'
-  );
-
-  t.deepEqual(
-    dt.columnArray('v'),
-    [2, 3, 4, 5],
-    'column array, numbers'
-  );
-
-  t.deepEqual(
-    dt.columnArray('v', Int32Array),
-    Int32Array.of(2, 3, 4, 5),
-    'column array, typed array'
   );
 
   t.end();

--- a/test/table/column-table-test.js
+++ b/test/table/column-table-test.js
@@ -119,7 +119,7 @@ tape('ColumnTable memoizes indices', t => {
   t.end();
 });
 
-tape('ColumnTable supports values output', t => {
+tape('ColumnTable supports column values output', t => {
   const dt = new ColumnTable({
       u: ['a', 'a', 'a', 'b', 'b'],
       v: [2, 1, 4, 5, 3]
@@ -130,19 +130,19 @@ tape('ColumnTable supports values output', t => {
   t.deepEqual(
     Array.from(dt.values('u')),
     ['a', 'b', 'a', 'b'],
-    'values, strings'
+    'column values, strings'
   );
 
   t.deepEqual(
     Array.from(dt.values('v')),
     [2, 3, 4, 5],
-    'values, numbers'
+    'column values, numbers'
   );
 
   t.deepEqual(
     Int32Array.from(dt.values('v')),
     Int32Array.of(2, 3, 4, 5),
-    'values, typed array'
+    'column values, typed array'
   );
 
   t.end();
@@ -157,19 +157,19 @@ tape('ColumnTable supports column array output', t => {
     .orderby('v');
 
   t.deepEqual(
-    dt.columnArray('u'),
+    dt.array('u'),
     ['a', 'b', 'a', 'b'],
     'column array, strings'
   );
 
   t.deepEqual(
-    dt.columnArray('v'),
+    dt.array('v'),
     [2, 3, 4, 5],
     'column array, numbers'
   );
 
   t.deepEqual(
-    dt.columnArray('v', Int32Array),
+    dt.array('v', Int32Array),
     Int32Array.of(2, 3, 4, 5),
     'column array, typed array'
   );


### PR DESCRIPTION
- Add table `values()` method to return an iterator over column values, respecting filter and orderby criteria.
- Add table `array()` method to return a column value array, respecting filter and orderby criteria.
- Deprecate table `columnArray()` method in favor of table `array()` method.