### PR TITLE
Add skip and comment options for fromCSV.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -131,6 +131,8 @@ This method performs parsing only. To both load and parse a CSV file, use [loadC
   * *delimiter*: A single-character delimiter string between column values (default `','`).
   * *decimal*: A single-character numeric decimal separator (default `'.'`).
   * *header*: Boolean flag (default `true`) to specify the presence of a  header row. If `true`, indicates the CSV contains a header row with column names. If `false`, indicates the CSV does not contain a header row and the columns are given the names `'col1'`, `'col2'`, and so on.
+  * *skip*: The number of lines to skip (default `0`) before reading data.
+  * *comment*: A string used to identify comment lines. Any lines that start with the comment pattern are skipped.
   * *autoType*: Boolean flag (default `true`) for automatic type inference.
   * *autoMax*: Maximum number of initial rows (default `1000`) to use for type inference.
   * *parse*: Object of column parsing options. The object keys should be column names. The object values should be parsing functions to invoke to transform values upon input.
@@ -141,6 +143,16 @@ This method performs parsing only. To both load and parse a CSV file, use [loadC
 // create table from an input CSV string
 // akin to table({ a: [1, 3], b: [2, 4] })
 aq.fromCSV('a,b\n1,2\n3,4')
+```
+
+```js
+// skip commented lines
+aq.fromCSV('# a comment\na,b\n1,2\n3,4', { comment: '#' })
+```
+
+```js
+// skip the first line
+aq.fromCSV('# a comment\na,b\n1,2\n3,4', { skip: 1 })
 ```
 
 ```js

--- a/src/format/from-csv.js
+++ b/src/format/from-csv.js
@@ -4,7 +4,6 @@ import identity from '../util/identity';
 import parseDSV from '../util/parse-dsv';
 import valueParser from '../util/parse-values';
 import repeat from '../util/repeat';
-import error from '../util/error';
 
 const DEFAULT_NAME = 'col';
 
@@ -17,6 +16,9 @@ const DEFAULT_NAME = 'col';
  *  If true, assumes the CSV contains a header row with column names.
  *  If false, indicates the CSV does not contain a header row, and the
  *  columns are given the names 'col1', 'col2', and so on.
+ * @property {number} [skip=0] The number of lines to skip before reading data.
+ * @property {string} [comment] A string used to identify comment lines. Any
+ *  lines that start with the comment pattern are skipped.
  * @property {boolean} [autoType=true] Flag for automatic type inference.
  * @property {number} [autoMax=1000] Maximum number of initial values to use
  *  for type inference.
@@ -38,12 +40,9 @@ const DEFAULT_NAME = 'col';
  * @param {ColumnTable} table A new table containing the parsed values.
  */
 export default function(text, options = {}) {
-  const delim = options.delimiter == null ? ',' : options.delimiter;
   const header = options.header !== false;
   const automax = +options.autoMax || 1000;
-
-  if (delim.length > 1) error('CSV delimiter should be a single character.');
-  const rows = parseDSV(text, (delim + '').charCodeAt(0));
+  const rows = parseDSV(text, options);
   let row = rows.next() || [];
 
   const n = row.length;

--- a/test/format/from-csv-test.js
+++ b/test/format/from-csv-test.js
@@ -83,3 +83,22 @@ tape('fromCSV parses delimited text with decimal option', t => {
   );
   t.end();
 });
+
+tape('fromCSV parses delimited text with skip options', t => {
+  const text = '# line 1\n# line 2\na,b\n1,2\n3,4';
+  const data = { a: [1, 3], b: [2, 4] };
+
+  tableEqual(t, fromCSV(text, { skip: 2 }), data,
+    'csv parsed data with skip option'
+  );
+
+  tableEqual(t, fromCSV(text, { comment: '#' }), data,
+    'csv parsed data with comment option'
+  );
+
+  tableEqual(t, fromCSV(text, { skip: 1, comment: '#' }), data,
+    'csv parsed data with skip and comment options'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
- Add `skip` and `comment` options for `fromCSV()`.

Close #165.