### PR TITLE
Improve output format methods.

### DIFF
--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -510,7 +510,7 @@ aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).print()
 Format this table as an HTML table string.
 
 * *options*: A formatting options object:
-  * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *limit*: The maximum number of rows to print (default `100`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
@@ -534,7 +534,7 @@ aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).toHTML()
 Format this table as a [GitHub-Flavored Markdown table](https://github.github.com/gfm/#tables-extension-) string.
 
 * *options*: A formatting options object:
-  * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *limit*: The maximum number of rows to print (default `100`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.

--- a/src/format/to-csv.js
+++ b/src/format/to-csv.js
@@ -39,7 +39,7 @@ export default function(table, options = {}) {
   const vals = names.map(formatValue);
   let text = '';
 
-  scan(table, names, options.limit, options.offset, {
+  scan(table, names, options.limit || Infinity, options.offset, {
     row() {
       text += vals.join(delim) + '\n';
     },

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -77,8 +77,8 @@ export default function(table, options = {}) {
   let r = -1;
   let idx = -1;
 
-  const tag = (tag, name) => {
-    const a = idx >= 0 && name ? alignValue(align[name]) : '';
+  const tag = (tag, name, shouldAlign) => {
+    const a = shouldAlign ? alignValue(align[name]) : '';
     const s = style[tag] ? (style[tag](name, idx, r) || '') : '';
     const css = (a ? (`text-align: ${a};` + (s ? ' ' : '')) : '') + s;
     return `<${tag}${css ? ` style="${css}"` : ''}>`;
@@ -87,7 +87,7 @@ export default function(table, options = {}) {
   let text = tag('table')
     + tag('thead')
     + tag('tr', r)
-    + names.map(name => `${tag('th', name)}${name}</th>`).join('')
+    + names.map(name => `${tag('th', name, 1)}${name}</th>`).join('')
     + '</tr></thead>'
     + tag('tbody');
 
@@ -97,7 +97,7 @@ export default function(table, options = {}) {
       text += (++idx ? '</tr>' : '') + tag('tr');
     },
     cell(value, name) {
-      text += tag('td', name)
+      text += tag('td', name, 1)
         + formatter(value, format[name])
         + '</td>';
     }

--- a/src/format/util.js
+++ b/src/format/util.js
@@ -57,7 +57,7 @@ function values(table, columnName) {
   return fn => table.scan(row => fn(column.get(row)));
 }
 
-export function scan(table, names, limit, offset, ctx) {
+export function scan(table, names, limit = 100, offset, ctx) {
   const data = table.data();
   const n = names.length;
   table.scan(row => {

--- a/test/format/to-html-test.js
+++ b/test/format/to-html-test.js
@@ -7,7 +7,7 @@ tape('toHTML formats html table text', t => {
   const r = 'style="text-align: right;"';
   const html = (u, v) => [
     '<table><thead>',
-    '<tr><th>u</th><th>v</th></tr>',
+    `<tr><th ${u}>u</th><th ${v}>v</th></tr>`,
     '</thead><tbody>',
     `<tr><td ${u}>a</td><td ${v}>1</td></tr>`,
     `<tr><td ${u}>a</td><td ${v}>2</td></tr>`,
@@ -39,7 +39,7 @@ tape('toHTML formats html table text with format option', t => {
   const r = 'style="text-align: right;"';
   const html = (u, v) => [
     '<table><thead>',
-    '<tr><th>u</th><th>v</th></tr>',
+    `<tr><th ${u}>u</th><th ${v}>v</th></tr>`,
     '</thead><tbody>',
     `<tr><td ${u}>aa</td><td ${v}>10</td></tr>`,
     `<tr><td ${u}>aa</td><td ${v}>20</td></tr>`,
@@ -70,11 +70,15 @@ tape('toHTML formats html table text with format option', t => {
 });
 
 tape('toHTML formats html table text with style option', t => {
-  const l = 'style="text-align: left; color: black;"';
-  const r = 'style="text-align: right; color: black;"';
+  const la = 'text-align: left;';
+  const ra = 'text-align: right;';
+  const cb = 'color: black;';
+  const l = `style="${la} ${cb}"`;
+  const r = `style="${ra} ${cb}"`;
   const html = (u, v) => [
     '<table><thead>',
-    '<tr style="row(-1,-1)"><th>u</th><th>v</th></tr>',
+    '<tr style="row(-1,-1)">',
+    `<th style="${la}">u</th><th style="${ra}">v</th></tr>`,
     '</thead><tbody>',
     `<tr style="row(0,1)"><td ${u}>a</td><td ${v}>1</td></tr>`,
     `<tr style="row(1,0)"><td ${u}>a</td><td ${v}>2</td></tr>`,
@@ -108,7 +112,7 @@ tape('toHTML formats html table text with null option', t => {
   const a = 'style="text-align: right;"';
   const html = (a) => [
     '<table><thead>',
-    '<tr><th>u</th></tr>',
+    `<tr><th ${a}>u</th></tr>`,
     '</thead><tbody>',
     `<tr><td ${a}>a</td></tr>`,
     `<tr><td ${a}>0</td></tr>`,


### PR DESCRIPTION
- Add default 100 row limit to `toHTML()` and `toMarkdown()`.
- Update to `toHTML()` to align column header similarly to the column body.

Close #175.
Close #176.