### PR TITLE
v4.7.0

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,7 +12,8 @@ title: Arquero API Reference
 * [Table Output](#output)
   * [toArrow](#toArrow)
 * [Expression Helpers](#expression-helpers)
-  * [op](#op), [bin](#bin), [desc](#desc), [frac](#frac), [rolling](#rolling), [seed](#seed)
+  * [op](#op), [agg](#agg)
+  * [bin](#bin), [desc](#desc), [frac](#frac), [rolling](#rolling), [seed](#seed)
 * [Selection Helpers](#selection-helpers)
   * [all](#all), [not](#not), [range](#range)
   * [matches](#matches), [startswith](#startswith), [endswith](#endswith)
@@ -486,6 +487,25 @@ Methods for invoking or modifying table expressions.
 <em>aq</em>.<b>op</b> · [Source](https://github.com/uwdata/arquero/blob/master/src/op/op-api.js)
 
 All table expression operations, including standard functions, aggregate functions, and window functions. See the [Operations API Reference](op) for documentation of all available functions.
+
+<hr/><a id="agg" href="#agg">#</a>
+<em>aq</em>.<b>agg</b>(<i>table</i>, <i>expression</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/verbs/helpers/agg.js)
+
+Compute a single aggregate value for a table. This method is a convenient shortcut for ungrouping a table, applying a [rollup](verbs/#rollup) verb for a single aggregate expression, and extracting the resulting aggregate value.
+
+* *table*: An Arquero table.
+* *expression*: An aggregate-valued table expression. Aggregate functions are permitted, and will take into account any [orderby](#orderby) settings. Window functions are not permitted and any [groupby](#groupby) settings will be ignored.
+
+*Examples*
+
+```js
+aq.agg(aq.table({ a: [1, 2, 3] }), op.max('a')) // 3
+```
+
+```js
+aq.agg(aq.table({ a: [1, 3, 5] }), d => [op.min(d.a), op.max('a')]) // [1, 5]
+```
+
 
 <hr/><a id="bin" href="#bin">#</a>
 <em>aq</em>.<b>bin</b>(<i>name</i>[, <i>options</i>]) · [Source](https://github.com/uwdata/arquero/blob/master/src/helpers/bin.js)

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -189,7 +189,7 @@ table.params({ hi: 5 }).filter((d, $) => abs(d.value) < $.hi)
 
 ## <a id="transformation">Table Transformation</a>
 
-For a variety of additional transformations, see the [verbs](verbs) API documentation.
+For a variety of additional transformations, see the [Verbs API Reference](verbs).
 
 <hr/><a id="assign" href="#assign">#</a>
 <em>table</em>.<b>assign</b>(<i>...tables</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -10,10 +10,12 @@ title: Table \| Arquero API Reference
   * [isFiltered](#isFiltered), [isGrouped](#isGrouped), [isOrdered](#isOrdered)
   * [comparator](#foo), [groups](#groups), [mask](#mask)
   * [params](#params)
+* [Table Transformation](#transformation)
+  * [assign](#assign)
+  * [transform](#transform)
 * [Table Columns](#columns)
   * [column](#column), [columnAt](#columnAt), [columnArray](#columnArray)
   * [columnIndex](#columnIndex), [columnName](#columnName), [columnNames](#columnNames)
-  * [assign](#assign)
 * [Table Values](#table-values)
   * [array](#array), [values](#values)
   * [data](#data), [get](#get), [getter](#getter)
@@ -185,6 +187,43 @@ table.params({ hi: 5 }).filter((d, $) => abs(d.value) < $.hi)
 
 <br/>
 
+## <a id="transformation">Table Transformation</a>
+
+For a variety of additional transformations, see the [verbs](verbs) API documentation.
+
+<hr/><a id="assign" href="#assign">#</a>
+<em>table</em>.<b>assign</b>(<i>...tables</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
+
+Create a new table with additional columns drawn from one or more input *tables*. All tables must have the same numer of rows and will be [reified](verbs/#reify) prior to assignment. In the case of repeated column names, input table columns overwrite existing columns.
+
+* *tables*: The input tables to merge.
+
+*Examples*
+
+```js
+const t1 = aq.table({ a: [1, 2], b: [3, 4] });
+const t2 = aq.table({ c: [5, 6], b: [7, 8] });
+t1.assign(t2); // { a: [1, 2], b: [7, 8], c: [5, 6] }
+```
+
+<hr/><a id="transform" href="#transform">#</a>
+<em>table</em>.<b>transform</b>(<i>...transforms</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
+
+Apply a sequence of transformations to this table. The output of each transform is passed as input to the next transform, and the output of the last transform is then returned. This method provides a lightweight mechanism for applying custom transformations to a table.
+
+* *transforms*: Transformation functions to apply to the table in sequence. Each function should take a single table as input and return a table as output.
+
+```js
+aq.table({ a: [1, 2], b: [3, 4] })
+  .transform(
+    table => table.filter(d => d.b > 3),
+    table => table.select('a')
+  ) // { a: [2] }
+```
+
+
+<br/>
+
 ## <a id="columns">Table Columns</a>
 
 <hr/><a id="column" href="#column">#</a>
@@ -272,20 +311,6 @@ aq.table({ a: [1, 2, 3], b: [4, 5, 6] })
   .columnNames(); // [ 'a', 'b' ]
 ```
 
-<hr/><a id="assign" href="#assign">#</a>
-<em>table</em>.<b>assign</b>(<i>...tables</i>) · [Source](https://github.com/uwdata/arquero/blob/master/src/table/column-table.js)
-
-Create a new table with additional columns drawn from one or more input *tables*. All tables must have the same numer of rows and will be [reified](verbs/#reify) prior to assignment. In the case of repeated column names, input table columns overwrite existing columns.
-
-* *tables*: The input tables to merge.
-
-*Examples*
-
-```js
-const t1 = aq.table({ a: [1, 2], b: [3, 4] });
-const t2 = aq.table({ c: [5, 6], b: [7, 8] });
-t1.assign(t2); // { a: [1, 2], b: [7, 8], c: [5, 6] }
-```
 
 <br/>
 

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -510,7 +510,7 @@ aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).print()
 Format this table as an HTML table string.
 
 * *options*: A formatting options object:
-  * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *limit*: The maximum number of rows to print (default `100`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.
@@ -534,7 +534,7 @@ aq.table({ a: [1, 2, 3], b: [4, 5, 6] }).toHTML()
 Format this table as a [GitHub-Flavored Markdown table](https://github.github.com/gfm/#tables-extension-) string.
 
 * *options*: A formatting options object:
-  * *limit*: The maximum number of rows to print (default `Infinity`).
+  * *limit*: The maximum number of rows to print (default `100`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
   * *columns*: Ordered list of column names to print. If function-valued, the function should accept a table as input and return an array of column name strings. Otherwise, should be an array of name strings.
   * *align*: Object of column alignment options. The object keys should be column names. The object values should be aligment strings, one of `'l'` (left), `'c'` (center), or `'r'` (right). If specified, these override any automatically inferred options.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arquero",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Query processing and transformation of array-backed data tables.",
   "keywords": [
     "data",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "^7.26.0",
     "esm": "^3.2.25",
     "rimraf": "^3.0.2",
-    "rollup": "^2.47.0",
+    "rollup": "^2.48.0",
     "rollup-plugin-bundle-size": "^1.0.3",
     "rollup-plugin-terser": "^7.0.2",
     "tape": "^5.2.2",

--- a/src/format/to-csv.js
+++ b/src/format/to-csv.js
@@ -39,7 +39,7 @@ export default function(table, options = {}) {
   const vals = names.map(formatValue);
   let text = '';
 
-  scan(table, names, options.limit, options.offset, {
+  scan(table, names, options.limit || Infinity, options.offset, {
     row() {
       text += vals.join(delim) + '\n';
     },

--- a/src/format/to-html.js
+++ b/src/format/to-html.js
@@ -77,8 +77,8 @@ export default function(table, options = {}) {
   let r = -1;
   let idx = -1;
 
-  const tag = (tag, name) => {
-    const a = idx >= 0 && name ? alignValue(align[name]) : '';
+  const tag = (tag, name, shouldAlign) => {
+    const a = shouldAlign ? alignValue(align[name]) : '';
     const s = style[tag] ? (style[tag](name, idx, r) || '') : '';
     const css = (a ? (`text-align: ${a};` + (s ? ' ' : '')) : '') + s;
     return `<${tag}${css ? ` style="${css}"` : ''}>`;
@@ -87,7 +87,7 @@ export default function(table, options = {}) {
   let text = tag('table')
     + tag('thead')
     + tag('tr', r)
-    + names.map(name => `${tag('th', name)}${name}</th>`).join('')
+    + names.map(name => `${tag('th', name, 1)}${name}</th>`).join('')
     + '</tr></thead>'
     + tag('tbody');
 
@@ -97,7 +97,7 @@ export default function(table, options = {}) {
       text += (++idx ? '</tr>' : '') + tag('tr');
     },
     cell(value, name) {
-      text += tag('td', name)
+      text += tag('td', name, 1)
         + formatter(value, format[name])
         + '</td>';
     }

--- a/src/format/util.js
+++ b/src/format/util.js
@@ -57,7 +57,7 @@ function values(table, columnName) {
   return fn => table.scan(row => fn(column.get(row)));
 }
 
-export function scan(table, names, limit, offset, ctx) {
+export function scan(table, names, limit = 100, offset, ctx) {
   const data = table.data();
   const n = names.length;
   table.scan(row => {

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export { default as field } from './helpers/field';
 export { default as frac } from './helpers/frac';
 export { default as rolling } from './helpers/rolling';
 export { all, endswith, matches, not, range, startswith } from './helpers/selection';
+export { default as agg } from './verbs/helpers/agg';
 export { default as op } from './op/op-api';
 export { query, queryFrom } from './query/query';
 export * from './register';

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -277,6 +277,19 @@ export default class ColumnTable extends Table {
   }
 
   /**
+   * Apply a sequence of transformations to this table. The output
+   * of each transform is passed as input to the next transform, and
+   * the output of the last transform is then returned.
+   * @param {...(Transform|Transform[])} transforms Transformation
+   *  functions to apply to the table in sequence. Each function should
+   *  take a single table as input and return a table as output.
+   * @return {ColumnTable} The output of the last transform.
+   */
+  transform(...transforms) {
+    return transforms.flat().reduce((t, f) => f(t), this);
+  }
+
+  /**
    * Format this table as an Apache Arrow table.
    * @param {ArrowFormatOptions} [options] The formatting options.
    * @return {import('apache-arrow').Table} An Apache Arrow table.
@@ -350,6 +363,11 @@ function objectBuilder(table) {
 
   return b;
 }
+
+/**
+ * A table transformation.
+ * @typedef {(table: ColumnTable) => ColumnTable} Transform
+ */
 
 /**
  * Proxy type for BitSet class.

--- a/src/verbs/helpers/agg.js
+++ b/src/verbs/helpers/agg.js
@@ -1,0 +1,14 @@
+/**
+ * Convenience function for computing a single aggregate value for
+ * a table. Equivalent to ungrouping a table, applying a rollup verb
+ * for a single aggregate, and extracting the resulting value.
+ * @param {import('../../table/Table')} table A table instance.
+ * @param {import('../../table/Transformable').TableExpr|string} expr An
+ *   aggregate table expression to evaluate.
+ * @return {import('../../table/Table').DataValue} The aggregate value.
+ * @example agg(table, op.max('colA'))
+ * @example agg(table, d => [op.min('colA'), op.max('colA')])
+ */
+export default function agg(table, expr) {
+  return table.ungroup().rollup({ _: expr }).get('_');
+}

--- a/test/format/to-html-test.js
+++ b/test/format/to-html-test.js
@@ -7,7 +7,7 @@ tape('toHTML formats html table text', t => {
   const r = 'style="text-align: right;"';
   const html = (u, v) => [
     '<table><thead>',
-    '<tr><th>u</th><th>v</th></tr>',
+    `<tr><th ${u}>u</th><th ${v}>v</th></tr>`,
     '</thead><tbody>',
     `<tr><td ${u}>a</td><td ${v}>1</td></tr>`,
     `<tr><td ${u}>a</td><td ${v}>2</td></tr>`,
@@ -39,7 +39,7 @@ tape('toHTML formats html table text with format option', t => {
   const r = 'style="text-align: right;"';
   const html = (u, v) => [
     '<table><thead>',
-    '<tr><th>u</th><th>v</th></tr>',
+    `<tr><th ${u}>u</th><th ${v}>v</th></tr>`,
     '</thead><tbody>',
     `<tr><td ${u}>aa</td><td ${v}>10</td></tr>`,
     `<tr><td ${u}>aa</td><td ${v}>20</td></tr>`,
@@ -70,11 +70,15 @@ tape('toHTML formats html table text with format option', t => {
 });
 
 tape('toHTML formats html table text with style option', t => {
-  const l = 'style="text-align: left; color: black;"';
-  const r = 'style="text-align: right; color: black;"';
+  const la = 'text-align: left;';
+  const ra = 'text-align: right;';
+  const cb = 'color: black;';
+  const l = `style="${la} ${cb}"`;
+  const r = `style="${ra} ${cb}"`;
   const html = (u, v) => [
     '<table><thead>',
-    '<tr style="row(-1,-1)"><th>u</th><th>v</th></tr>',
+    '<tr style="row(-1,-1)">',
+    `<th style="${la}">u</th><th style="${ra}">v</th></tr>`,
     '</thead><tbody>',
     `<tr style="row(0,1)"><td ${u}>a</td><td ${v}>1</td></tr>`,
     `<tr style="row(1,0)"><td ${u}>a</td><td ${v}>2</td></tr>`,
@@ -108,7 +112,7 @@ tape('toHTML formats html table text with null option', t => {
   const a = 'style="text-align: right;"';
   const html = (a) => [
     '<table><thead>',
-    '<tr><th>u</th></tr>',
+    `<tr><th ${a}>u</th></tr>`,
     '</thead><tbody>',
     `<tr><td ${a}>a</td></tr>`,
     `<tr><td ${a}>0</td></tr>`,

--- a/test/table/column-table-test.js
+++ b/test/table/column-table-test.js
@@ -499,3 +499,19 @@ tape('ColumnTable assign merges tables', t => {
 
   t.end();
 });
+
+tape('ColumnTable transform applies transformations', t => {
+  const dt = new ColumnTable({ a: [1, 2], b: [2, 3], c: [3, 4] });
+
+  tableEqual(t,
+    dt.transform(
+      t => t.filter(d => d.c > 3),
+      t => t.select('a', 'b'),
+      t => t.reify()
+    ),
+    { a: [2], b: [3] },
+    'transform pipeline'
+  );
+
+  t.end();
+});

--- a/test/verbs/agg-test.js
+++ b/test/verbs/agg-test.js
@@ -1,0 +1,18 @@
+import tape from 'tape';
+import { agg, op, table } from '../../src';
+
+tape('agg computes aggregate values', t => {
+  const dt = table({ a: [1, 2, 3, 4] });
+
+  t.deepEqual(
+    {
+      sum: agg(dt, op.sum('a')),
+      max: agg(dt, op.max('a')),
+      ext: agg(dt, d => [op.min(d.a), op.max(d.a)])
+    },
+    { sum: 10, max: 4, ext: [1, 4] },
+    'agg helper'
+  );
+
+  t.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,9 +84,9 @@
   integrity sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA==
 
 "@types/node@*":
-  version "15.0.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.3.tgz#ee09fcaac513576474c327da5818d421b98db88a"
-  integrity sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
+  integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
 
 "@types/node@^12.0.4":
   version "12.20.13"
@@ -131,9 +131,9 @@ ajv@^6.10.0, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.3.0.tgz#25ee7348e32cdc4a1dbb38256bf6bdc451dd577c"
-  integrity sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.4.0.tgz#48984fdb2ce225cab15795f0772a8d85669075e4"
+  integrity sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -1270,10 +1270,10 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.47.0:
-  version "2.47.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.47.0.tgz#9d958aeb2c0f6a383cacc0401dff02b6e252664d"
-  integrity sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==
+rollup@^2.48.0:
+  version "2.48.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.48.0.tgz#fceb01ed771f991f29f7bd2ff7838146e55acb74"
+  integrity sha512-wl9ZSSSsi5579oscSDYSzGn092tCS076YB+TQrzsGuSfYyJeep8eEWj0eaRjuC5McuMNmcnR8icBqiE/FWNB1A==
   optionalDependencies:
     fsevents "~2.3.1"
 
@@ -1433,9 +1433,9 @@ table-layout@^0.4.3:
     wordwrapjs "^3.0.0"
 
 table@^6.0.4:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.7.0.tgz#26274751f0ee099c547f6cb91d3eff0d61d155b2"
-  integrity sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
+  integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
   dependencies:
     ajv "^8.0.1"
     lodash.clonedeep "^4.5.0"


### PR DESCRIPTION
Changes from [v4.6.0](https://github.com/uwdata/arquero/releases/tag/v4.6.0):

- Add table [`transform()`](https://uwdata.github.io/arquero/api/table#transform) method to allow lightweight application of custom transformations.
- Add [`agg()`](https://uwdata.github.io/arquero/api/#agg) helper method as a shorthand for computing a single aggregate value.
- Add default 100 row limit to [`toHTML()`](https://uwdata.github.io/arquero/api/table#toHTML) and [`toMarkdown()`](https://uwdata.github.io/arquero/api/table#toMarkdown). (#175)
- Update to [`toHTML()`](https://uwdata.github.io/arquero/api/table#toHTML) to align column header similarly to the column body. (#176)