### PR TITLE
Update TypeScript types, expression literals.

### DIFF
--- a/src/engine/rollup.js
+++ b/src/engine/rollup.js
@@ -17,7 +17,7 @@ export default function(table, { names, exprs, ops }) {
 }
 
 function output(names, exprs, groups, result = [], cols) {
-  if (!result.length) return;
+  if (!exprs.length) return;
   const size = groups ? groups.size : 1;
   const op = (id, row) => result[id][row];
   const n = names.length;

--- a/src/expression/parse-escape.js
+++ b/src/expression/parse-escape.js
@@ -1,6 +1,7 @@
 import compile from './compile';
 import { rowObjectCode } from './row-object';
 import error from '../util/error';
+import toFunction from '../util/to-function';
 
 const ERROR_ESC_AGGRONLY = 'Escaped functions are not valid as rollup or pivot values.';
 
@@ -12,5 +13,5 @@ export default function(ctx, spec, params) {
     + rowObjectCode(ctx.table.columnNames())
     + ',$)';
 
-  return { escape: compile.escape(code, spec.expr, params) };
+  return { escape: compile.escape(code, toFunction(spec.expr), params) };
 }

--- a/src/expression/parse-expression.js
+++ b/src/expression/parse-expression.js
@@ -11,6 +11,7 @@ import {
   Parameter,
   Property
 } from './ast/constants';
+import { is, isFunctionExpression } from './ast/util';
 import walk from './ast/walk';
 import constants from './constants';
 import rewrite from './rewrite';
@@ -19,10 +20,12 @@ import {
   getAggregate, getWindow,
   hasAggregate, hasFunction, hasWindow
 } from '../op';
+
 import error from '../util/error';
 import has from '../util/has';
+import isArray from '../util/is-array';
 import isNumber from '../util/is-number';
-import { is, isFunctionExpression } from './ast/util';
+import toString from '../util/to-string';
 
 const PARSER_OPT = { ecmaVersion: 11 };
 const DEFAULT_PARAM_ID = '$';
@@ -87,7 +90,9 @@ export default function parseExpression(ctx, spec) {
 
 function parseAST(expr) {
   try {
-    const code = expr.field ? fieldRef(expr) : expr;
+    const code = expr.field ? fieldRef(expr)
+      : isArray(expr) ? toString(expr)
+      : expr;
     return parse(`expr=(${code})`, PARSER_OPT).body[0].expression.right;
   } catch (err) {
     error(`Expression parse error: ${expr+''}`, err);

--- a/src/op/op-api.js
+++ b/src/op/op-api.js
@@ -1,5 +1,5 @@
 import functions from './functions';
-import op, { Op } from './op'; // eslint-disable-line no-unused-vars
+import op from './op';
 
 export const any = (field) => op('any', field);
 export const count = () => op('count');
@@ -8,6 +8,10 @@ export const array_agg_distinct = (field) => op('array_agg_distinct', field);
 export const map_agg = (key, value) => op('map_agg', [key, value]);
 export const object_agg = (key, value) => op('object_agg', [key, value]);
 export const entries_agg = (key, value) => op('entries_agg', [key, value]);
+
+/**
+ * @typedef {import('../table/transformable').Struct} Struct
+ */
 
 /**
  * All table expression operations including normal functions,
@@ -20,34 +24,34 @@ export default {
    * Generate an object representing the current table row.
    * @param {...string} names The column names to include in the object.
    *  If unspecified, all columns are included.
-   * @return {Op} An operation for the generated row object.
+   * @return {Struct} The generated row object.
    */
   row_object: (...names) => op('row_object', null, names.flat()),
 
   /**
    * Aggregate function to count the number of records (rows).
-   * @returns {Op} An operation for the count of records.
+   * @returns {number} The count of records.
    */
   count,
 
   /**
    * Aggregate function returning an arbitrary observed value.
    * @param {*} field The data field.
-   * @return {Op} An operation for an arbitrary observed value.
+   * @return {*} An arbitrary observed value.
    */
   any,
 
   /**
    * Aggregate function to collect an array of values.
    * @param {*} field The data field.
-   * @return {Op} An operation for a list of values.
+   * @return {Array} A list of values.
    */
   array_agg,
 
   /**
    * Aggregate function to collect an array of distinct (unique) values.
    * @param {*} field The data field.
-   * @return {Op} An operation for an array of unique values.
+   * @return {Array} An array of unique values.
    */
   array_agg_distinct,
 
@@ -55,7 +59,7 @@ export default {
    * Aggregate function to create an object given input key and value fields.
    * @param {*} key The object key field.
    * @param {*} value The object value field.
-   * @return {Op} An operation for an object of key-value pairs.
+   * @return {Struct} An object of key-value pairs.
    */
   object_agg,
 
@@ -63,7 +67,7 @@ export default {
    * Aggregate function to create a Map given input key and value fields.
    * @param {*} key The object key field.
    * @param {*} value The object value field.
-   * @return {Op} An operation for a Map of key-value pairs.
+   * @return {Map} A Map of key-value pairs.
    */
   map_agg,
 
@@ -72,7 +76,7 @@ export default {
    * given input key and value fields.
    * @param {*} key The object key field.
    * @param {*} value The object value field.
-   * @return {Op} An operation for an array of [key, value] arrays.
+   * @return {[[any, any]]} An array of [key, value] arrays.
    */
   entries_agg,
 
@@ -80,7 +84,7 @@ export default {
    * Aggregate function to count the number of valid values.
    * Invalid values are null, undefined, or NaN.
    * @param {*} field The data field.
-   * @return {Op} An operation for the count of valid values.
+   * @return {number} The count of valid values.
    */
   valid: (field) => op('valid', field),
 
@@ -88,91 +92,91 @@ export default {
    * Aggregate function to count the number of invalid values.
    * Invalid values are null, undefined, or NaN.
    * @param {*} field The data field.
-   * @return {Op} An operation for the count of invalid values.
+   * @return {number} The count of invalid values.
    */
   invalid: (field) => op('invalid', field),
 
   /**
    * Aggregate function to count the number of distinct values.
    * @param {*} field The data field.
-   * @return {Op} An operation for the count of distinct values.
+   * @return {number} The count of distinct values.
    */
   distinct: (field) => op('distinct', field),
 
   /**
    * Aggregate function to determine the mode (most frequent) value.
    * @param {*} field The data field.
-   * @return {Op} An operation for the mode value.
+   * @return {number} The mode value.
    */
   mode: (field) => op('mode', field),
 
   /**
    * Aggregate function to sum values.
-   * @param {*} field The data field.
-   * @return {Op} An operation for the sum of the values.
+   * @param {string} field The data field.
+   * @return {number} The sum of the values.
    */
   sum: (field) => op('sum', field),
 
   /**
    * Aggregate function to multiply values.
    * @param {*} field The data field.
-   * @return {Op} An operation for the product of the values.
+   * @return {number} The product of the values.
    */
   product: (field) => op('product', field),
 
   /**
    * Aggregate function for the mean (average) value.
    * @param {*} field The data field.
-   * @return {Op} An operation for the mean (average) of the values.
+   * @return {number} The mean (average) of the values.
    */
   mean: (field) => op('mean', field),
 
   /**
    * Aggregate function for the average (mean) value.
    * @param {*} field The data field.
-   * @return {Op} An operation for the average (mean) of the values.
+   * @return {number} The average (mean) of the values.
    */
   average: (field) => op('average', field),
 
   /**
    * Aggregate function for the sample variance.
    * @param {*} field The data field.
-   * @return {Op} An operation for the sample variance of the values.
+   * @return {number} The sample variance of the values.
    */
   variance: (field) => op('variance', field),
 
   /**
    * Aggregate function for the population variance.
    * @param {*} field The data field.
-   * @return {Op} An operation for the population variance of the values.
+   * @return {number} The population variance of the values.
    */
   variancep: (field) => op('variancep', field),
 
   /**
    * Aggregate function for the sample standard deviation.
    * @param {*} field The data field.
-   * @return {Op} An operation for the sample standard deviation of the values.
+   * @return {number} The sample standard deviation of the values.
    */
   stdev: (field) => op('stdev', field),
 
   /**
    * Aggregate function for the population standard deviation.
    * @param {*} field The data field.
-   * @return {Op} An operation for the population standard deviation of the values.
+   * @return {number} The population standard deviation of the values.
    */
   stdevp: (field) => op('stdevp', field),
 
   /**
    * Aggregate function for the minimum value.
    * @param {*} field The data field.
-   * @return {Op} An operation for the minimum value.
+   * @return {number} The minimum value.
    */
   min: (field) => op('min', field),
 
   /**
    * Aggregate function for the maximum value.
    * @param {*} field The data field.
-   * @return {Op} An operation for the maximum value.
+   * @return {number} The maximum value.
    */
   max: (field) => op('max', field),
 
@@ -181,7 +185,7 @@ export default {
    * of a data field for a probability threshold.
    * @param {*} field The data field.
    * @param {number} p The probability threshold.
-   * @return {Op} An operation for a quantile value.
+   * @return {number} The quantile value.
    */
   quantile: (field, p) => op('quantile', field, p),
 
@@ -189,7 +193,7 @@ export default {
    * Aggregate function for the median value.
    * This is a shorthand for the 0.5 quantile value.
    * @param {*} field The data field.
-   * @return {Op} An operation for the median value.
+   * @return {number} The median value.
    */
   median: (field) => op('median', field),
 
@@ -197,7 +201,7 @@ export default {
    * Aggregate function for the sample covariance between two variables.
    * @param {*} field1 The first data field.
    * @param {*} field2 The second data field.
-   * @return {Op} An operation for the sample covariance of the values.
+   * @return {number} The sample covariance of the values.
    */
   covariance: (field1, field2) => op('covariance', [field1, field2]),
 
@@ -205,7 +209,7 @@ export default {
    * Aggregate function for the population covariance between two variables.
    * @param {*} field1 The first data field.
    * @param {*} field2 The second data field.
-   * @return {Op} An operation for the population covariance of the values.
+   * @return {number} The population covariance of the values.
    */
   covariancep: (field1, field2) => op('covariancep', [field1, field2]),
 
@@ -215,7 +219,7 @@ export default {
    * variable and then apply this function to the result.
    * @param {*} field1 The first data field.
    * @param {*} field2 The second data field.
-   * @return {Op} An operation for the correlation between the field values.
+   * @return {number} The correlation between the field values.
    */
   corr: (field1, field2) => op('corr', [field1, field2]),
 
@@ -229,14 +233,14 @@ export default {
    * @param {number} [minstep] The minimum allowed step size between bins.
    * @param {number} [step] The exact step size to use between bins.
    *  If specified, the maxbins and minstep arguments are ignored.
-   * @return {Op} An operation for the bin [min, max, and step] values.
+   * @return {[number, number, number]} The bin [min, max, and step] values.
    */
   bins: (field, maxbins, nice, minstep) =>
     op('bins', field, [maxbins, nice, minstep]),
 
   /**
    * Window function to assign consecutive row numbers, starting from 1.
-   * @return {Op} An operation for the row number value.
+   * @return {number} The row number value.
    */
   row_number: () => op('row_number'),
 
@@ -245,7 +249,7 @@ export default {
    * from 1. Peer values are assigned the same rank. Subsequent ranks
    * reflect the number of prior values: if the first two values tie for
    * rank 1, the third value is assigned rank 3.
-   * @return {Op} An operation for the rank value.
+   * @return {number} The rank value.
    */
   rank: () => op('rank'),
 
@@ -253,7 +257,7 @@ export default {
    * Window function to assign a fractional (average) rank to each value in
    * a group, starting from 1. Peer values are assigned the average of their
    * indices: if the first two values tie, both will be assigned rank 1.5.
-   * @return {Op} An operation for the peer-averaged rank value.
+   * @return {number} The peer-averaged rank value.
    */
   avg_rank: () => op('avg_rank'),
 
@@ -262,21 +266,21 @@ export default {
    * starting from 1. Peer values are assigned the same rank. Subsequent
    * ranks do not reflect the number of prior values: if the first two
    * values tie for rank 1, the third value is assigned rank 2.
-   * @return {Op} An operation for the dense rank value.
+   * @return {number} The dense rank value.
    */
   dense_rank: () => op('dense_rank'),
 
   /**
    * Window function to assign a percentage rank to each value in a group.
    * The percent is calculated as (rank - 1) / (group_size - 1).
-   * @return {Op} An operation for the percentage rank value.
+   * @return {number} The percentage rank value.
    */
   percent_rank: () => op('percent_rank'),
 
   /**
    * Window function to assign a cumulative distribution value between 0 and 1
    * to each value in a group.
-   * @return {Op} An operation for the cumulative distribution value.
+   * @return {number} The cumulative distribution value.
    */
   cume_dist: () => op('cume_dist'),
 
@@ -285,7 +289,7 @@ export default {
    * value in a group. Accepts an integer parameter indicating the number of
    * buckets to use (e.g., 100 for percentiles, 5 for quintiles).
    * @param {number} num The number of buckets for ntile calculation.
-   * @return {Op} An operation for the quantile value.
+   * @return {number} The quantile value.
    */
   ntile: (num) => op('ntile', null, num),
 
@@ -296,7 +300,7 @@ export default {
    * @param {*} field The data field.
    * @param {number} [offset=1] The lag offset from the current value.
    * @param {*} [defaultValue=undefined] The default value.
-   * @return {Op} An operation for a lagging value.
+   * @return {*} The lagging value.
    */
   lag: (field, offset, defaultValue) => op('lag', field, [offset, defaultValue]),
 
@@ -307,21 +311,21 @@ export default {
    * @param {*} field The data field.
    * @param {number} [offset=1] The lead offset from the current value.
    * @param {*} [defaultValue=undefined] The default value.
-   * @return {Op} An operation for a leading value.
+   * @return {*} The leading value.
    */
   lead: (field, offset, defaultValue) => op('lead', field, [offset, defaultValue]),
 
   /**
    * Window function to assign the first value in a sliding window frame.
    * @param {*} field The data field.
-   * @return {Op} An operation for the first value in the current frame.
+   * @return {*} The first value in the current frame.
    */
   first_value: (field) => op('first_value', field),
 
   /**
    * Window function to assign the last value in a sliding window frame.
    * @param {*} field The data field.
-   * @return {Op} An operation for the last value in the current frame.
+   * @return {*} The last value in the current frame.
    */
   last_value: (field) => op('last_value', field),
 
@@ -330,7 +334,7 @@ export default {
    * (counting from 1), or undefined if no such value exists.
    * @param {*} field The data field.
    * @param {number} nth The nth position, starting from 1.
-   * @return {Op} An operation for the nth value in the current frame.
+   * @return {*} The nth value in the current frame.
    */
   nth_value: (field, nth) => op('nth_value', field, nth),
 
@@ -338,9 +342,8 @@ export default {
    * Window function to fill in missing values with preceding values.
    * @param {*} field The data field.
    * @param {*} [defaultValue=undefined] The default value.
-   * @return {Op} An operation for the current value if valid, otherwise
-   *  the first preceding valid value. If no such value exists, the
-   *  operation returns the default value.
+   * @return {*} The current value if valid, otherwise the first preceding
+   *  valid value. If no such value exists, returns the default value.
    */
   fill_down: (field, defaultValue) => op('fill_down', field, defaultValue),
 
@@ -348,9 +351,8 @@ export default {
    * Window function to fill in missing values with subsequent values.
    * @param {*} field The data field.
    * @param {*} [defaultValue=undefined] The default value.
-   * @return {Op} An operation for the current value if valid, otherwise
-   *  the first subsequent valid value. If no such value exists, the
-   *  operation returns the default value.
+   * @return {*} The current value if valid, otherwise the first subsequent
+   *  valid value. If no such value exists, returns the default value.
    */
   fill_up: (field, defaultValue) => op('fill_up', field, defaultValue)
 };

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -288,13 +288,13 @@ export default class Transformable {
    * If the expand option is specified, imputes new rows for missing
    * combinations of values. All combinations of key values (a full cross
    * product) are considered for each level of grouping (specified by
-   * {@link Table#groupby}). New rows will be added for any combination of
-   * key and groupby values not already contained in the table. For all
+   * {@link Transformable#groupby}). New rows will be added for any combination
+   * of key and groupby values not already contained in the table. For all
    * non-key and non-group columns the new rows are populated with imputation
    * values (first argument) if specified, otherwise undefined.
    * If the expand option is specified, any filter or orderby settings are
    * removed from the output table, but groupby settings persist.
-   * @param {object} values Object of name-value pairs for the column values
+   * @param {ExprObject} values Object of name-value pairs for the column values
    *  to impute. The input object should have existing column names for keys
    *  and table expressions for values. The expressions will be evaluated to
    *  determine replacements for any missing values.
@@ -303,7 +303,7 @@ export default class Transformable {
    *  missing rows. All combinations of expanded values are considered, and
    *  new rows are added for each combination that does not appear in the
    *  input table.
-   * @return {Table} A new table with imputed values and/or rows.
+   * @return {this} A new table with imputed values and/or rows.
    * @example table.impute({ v: () => 0 })
    * @example table.impute({ v: d => op.mean(d.v) })
    * @example table.impute({ v: () => 0 }, { expand: ['x', 'y'] })
@@ -729,19 +729,24 @@ export default class Transformable {
  */
 
 /**
- * A function defined over a table row.
+ * A value that can be coerced to a string.
  * @typedef {object} Stringable
  * @property {() => string} toString String coercion method.
  */
 
 /**
- * A table expression provided as a string or string-coercible object.
+ * A table expression provided as a string or string-coercible value.
  * @typedef {string|Stringable} TableExprString
  */
 
 /**
+ * A struct object with arbitraty named properties.
+ * @typedef {Object.<string, *>} Struct
+ */
+
+/**
  * A function defined over a table row.
- * @typedef {(d?: object, $?: Params) => any} TableExprFunc
+ * @typedef {(d?: Struct, $?: Params) => any} TableExprFunc
  */
 
 /**
@@ -751,7 +756,7 @@ export default class Transformable {
 
 /**
  * A function defined over rows from two tables.
- * @typedef {(a?: object, b?: object, $?: Params) => any} TableFunc2
+ * @typedef {(a?: Struct, b?: Struct, $?: Params) => any} TableFunc2
  */
 
 /**
@@ -908,11 +913,12 @@ export default class Transformable {
 /**
  * Options for impute transformations.
  * @typedef {object} ImputeOptions
- * @property {any} [expand] Column values to combine to impute missing rows.
- *  For columns names and indices, all unique column values are considered.
- *  Otherwise, each entry should be an object of name-expresion pairs, with
- *  valid table expressions for {@link Table#rollup}. All combinations of
- *  values are checked for each set of unique groupby values.
+ * @property {ExprList} [expand] Column values to combine to impute missing
+ *  rows. For column names and indices, all unique column values are
+ *  considered. Otherwise, each entry should be an object of name-expresion
+ *  pairs, with valid table expressions for {@link Transformable#rollup}.
+ *  All combinations of values are checked for each set of unique groupby
+ *  values.
  */
 
 /**

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -862,7 +862,7 @@ export default class Transformable {
  */
 
 /**
- * Options for relocate transformations.
+ * Options for derive transformations.
  * @typedef {object} DeriveOptions
  * @property {boolean} [drop=false] A flag indicating if the original
  *  columns should be dropped, leaving only the derived columns. If true,

--- a/src/util/to-array.js
+++ b/src/util/to-array.js
@@ -1,6 +1,6 @@
 import isArray from './is-array';
 
-export default function toArray(value) {
+export default function(value) {
   return value != null
     ? (isArray(value) ? value : [value])
     : [];

--- a/src/util/to-function.js
+++ b/src/util/to-function.js
@@ -1,0 +1,5 @@
+import isFunction from './is-function';
+
+export default function(value) {
+  return isFunction(value) ? value : () => value;
+}

--- a/src/verbs/impute.js
+++ b/src/verbs/impute.js
@@ -14,7 +14,8 @@ export default function(table, values, options = {}) {
   );
 
   if (options.expand) {
-    const params = parseValues('impute', table, options.expand, { preparse });
+    const opt = { preparse, aggronly: true };
+    const params = parseValues('impute', table, options.expand, opt);
     const result = _rollup(table.ungroup(), params);
     return _impute(
       table, values, params.names,

--- a/test/helpers/escape-test.js
+++ b/test/helpers/escape-test.js
@@ -26,6 +26,12 @@ tape('derive supports escaped functions', t => {
     'derive data with escape, op, and params'
   );
 
+  tableEqual(t,
+    dt.derive({ z: escape(2) }),
+    { a: [1, 2], b: [3, 4], z: [2, 2] },
+    'derive data with escaped literal value'
+  );
+
   t.end();
 });
 

--- a/test/verbs/impute-test.js
+++ b/test/verbs/impute-test.js
@@ -60,7 +60,7 @@ tape('impute imputes expanded rows for an ungrouped table', t => {
   tableEqual(t, dt, {
     x: ['a', 'a', 'a', 'b', 'b', 'b', 'c', 'c', 'c'],
     y: [ 1,   2,   3,   1,   2,   3,   1,   2,   3 ],
-    z: ['x', na,  na,  na, 'x',  na,  na,  na, 'x']
+    z: ['x', na,  na,  na, 'x',  na,  na,  na,  'x']
   }, 'impute data');
 
   t.equal(dt.groups(), null, 'no groups');
@@ -68,7 +68,7 @@ tape('impute imputes expanded rows for an ungrouped table', t => {
   t.end();
 });
 
-tape('imputes imputes expanded rows for a grouped table', t => {
+tape('impute imputes expanded rows for a grouped table', t => {
   const dt = table({
       x: ['a', 'a', 'b', 'c'],
       y: [1, 1, 2, 3],
@@ -118,7 +118,7 @@ tape('impute imputes values and rows for an ungrouped table', t => {
   t.end();
 });
 
-tape('imputes imputes expanded rows for a grouped table', t => {
+tape('impute imputes expanded rows for a grouped table', t => {
   const dt = table({
       x: ['a', 'a', 'b', 'c'],
       y: [1, 1, 2, 3],
@@ -127,6 +127,34 @@ tape('imputes imputes expanded rows for a grouped table', t => {
     })
     .groupby('x', 'y')
     .impute({ v: op.max('v') }, { expand: 'z' })
+    .orderby('x', 'y', 'z')
+    .reify();
+
+  tableEqual(t, dt, {
+    x: ['a', 'a', 'a', 'a', 'b', 'b', 'b', 'c', 'c', 'c'],
+    y: [ 1,   1,   1,   1,   2,   2,   2,   3,   3,   3 ],
+    z: ['x', 'x', 'y', 'z', 'x', 'y', 'z', 'x', 'y', 'z'],
+    v: [ 0,   9,   9,   9,   8,   8,   8,   7,   7,   7 ]
+  }, 'impute data');
+
+  t.deepEqual(
+    Array.from(dt.groups().keys),
+    [0, 0, 0, 0, 1, 1, 1, 2, 2, 2],
+    'group keys'
+  );
+
+  t.end();
+});
+
+tape('impute imputes expanded rows given fixed values', t => {
+  const dt = table({
+      x: ['a', 'a', 'b', 'c'],
+      y: [1, 1, 2, 3],
+      z: ['x', 'x', 'y', 'z'],
+      v: [0, 9, 8, 7]
+    })
+    .groupby('x', 'y')
+    .impute({ v: op.max('v') }, { expand: { z: ['x', 'y', 'z'] } })
     .orderby('x', 'y', 'z')
     .reify();
 


### PR DESCRIPTION
* Add support for array literals and escaped values in expression parsing.
* Fix `rollup()` output early exit condition to support literal expressions without aggregate operations.
* Improve TypeScript types. (#182)
* Update impute verb tests.