### PR TITLE
Fix setting limit in print()

### DIFF
--- a/src/table/table.js
+++ b/src/table/table.js
@@ -276,7 +276,7 @@ export default class Table extends Transformable {
    */
   print(options = {}) {
     if (typeof options === 'number') {
-      options = { limit: 10 };
+      options = { limit: options };
     } else if (options.limit == null) {
       options.limit = 10;
     }


### PR DESCRIPTION
When using `print()`, the default value is 10. Users can override this value by setting `limit` in the options object or by providing a numeric value. Unfortunately, if a numeric value was set, the default of 10 was used instead of the provided value.