### PR TITLE
v4.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arquero",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Query processing and transformation of array-backed data tables.",
   "keywords": [
     "data",

--- a/src/arrow/builder/date-millis-builder.js
+++ b/src/arrow/builder/date-millis-builder.js
@@ -1,7 +1,7 @@
 import { array } from './util';
 
 export default function(type, length) {
-  const data = array(type.ArrayType, length);
+  const data = array(type.ArrayType, length << 1);
   return {
     set(value, index) {
       const i = index << 1;

--- a/test/arrow/data-from-test.js
+++ b/test/arrow/data-from-test.js
@@ -38,7 +38,13 @@ function dateTest(t, type) {
     date(2000, 0, 1),
     date(2004, 10, 12),
     date(2007, 3, 14),
-    date(2009, 6, 26)
+    date(2009, 6, 26),
+    date(2000, 0, 1),
+    date(2004, 10, 12),
+    date(2007, 3, 14),
+    date(2009, 6, 26),
+    date(2000, 0, 1),
+    date(2004, 10, 12)
   ];
   valueTest(t, type, values, ', without nulls');
   valueTest(t, type, [null, ...values, undefined], ', with nulls');


### PR DESCRIPTION
Changes from [v4.8.3](https://github.com/uwdata/arquero/releases/tag/v4.8.3):

- Fix Arrow vector builder for millisecond dates. (#213)

Close #213.