### PR TITLE
Fix mismatched imports due to casing

### DIFF
--- a/src/verbs/helpers/agg.js
+++ b/src/verbs/helpers/agg.js
@@ -5,9 +5,9 @@ import Table from '../../table/table'; // eslint-disable-line no-unused-vars
  * a table. Equivalent to ungrouping a table, applying a rollup verb
  * for a single aggregate, and extracting the resulting value.
  * @param {Table} table A table instance.
- * @param {import('../../table/Transformable').TableExpr} expr An
+ * @param {import('../../table/transformable').TableExpr} expr An
  *   aggregate table expression to evaluate.
- * @return {import('../../table/Table').DataValue} The aggregate value.
+ * @return {import('../../table/table').DataValue} The aggregate value.
  * @example agg(table, op.max('colA'))
  * @example agg(table, d => [op.min('colA'), op.max('colA')])
  */


### PR DESCRIPTION
This mismatching in case causes typescript to throw an error when compiling/linting Arquero as a dependency.