### PR TITLE
Implement params support for Query::toAST

### DIFF
--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -101,9 +101,14 @@ function getParams(opt) {
         ...getTableParams(opt.join[1]),
         ...getTableParams(opt.join[0])
       }
+    : opt.query ? getQueryParams(opt.query)
     : {}) || {};
 }
 
 function getTableParams(table) {
   return table && isFunction(table.params) ? table.params() : {};
+}
+
+function getQueryParams(query) {
+  return query && isFunction(query.params) ? query.params() : {};
 }

--- a/src/query/query.js
+++ b/src/query/query.js
@@ -156,7 +156,7 @@ export default class Query extends Transformable {
 function serialize(query, method, props) {
   return {
     ...props,
-    verbs: query._verbs.map(verb => verb[method]()),
+    verbs: query._verbs.map(verb => verb[method]({query})),
     ...(query._params ? { params: query._params } : null),
     ...(query._table ? { table: query._table } : null)
   };

--- a/src/query/to-ast.js
+++ b/src/query/to-ast.js
@@ -100,57 +100,57 @@ function astExprObject(obj, opt) {
     }));
 }
 
-function astSelection(sel) {
+function astSelection(sel, opt) {
   const type = Selection;
   return sel.all ? { type, operator: 'all' }
-    : sel.not ? { type, operator: 'not', arguments: astExprList(sel.not) }
-    : sel.range ? { type, operator: 'range', arguments: astExprList(sel.range) }
+    : sel.not ? { type, operator: 'not', arguments: astExprList(sel.not, opt) }
+    : sel.range ? { type, operator: 'range', arguments: astExprList(sel.range, opt) }
     : sel.matches ? { type, operator: 'matches', arguments: sel.matches }
     : error('Invalid input');
 }
 
-function astSelectionList(arr) {
-  return toArray(arr).map(astSelectionItem).flat();
+function astSelectionList(arr, opt) {
+  return toArray(arr).map(item => astSelectionItem(item, opt)).flat();
 }
 
-function astSelectionItem(val) {
-  return isSelection(val) ? astSelection(val)
-    : isNumber(val) ? astColumnIndex(val)
-    : isString(val) ? astColumn(val)
+function astSelectionItem(val, opt) {
+  return isSelection(val) ? astSelection(val, opt)
+    : isNumber(val) ? astColumnIndex(val, opt)
+    : isString(val) ? astColumn(val, opt)
     : isObject(val) ? Object.keys(val)
       .map(name => ({ type: Column, name, as: val[name] }))
     : error('Invalid input');
 }
 
-function astExpr(val) {
-  return isSelection(val) ? astSelection(val)
-    : isNumber(val) ? astColumnIndex(val)
-    : isString(val) ? astColumn(val)
-    : isObject(val) ? astExprObject(val)
+function astExpr(val, opt) {
+  return isSelection(val) ? astSelection(val, opt)
+    : isNumber(val) ? astColumnIndex(val, opt)
+    : isString(val) ? astColumn(val, opt)
+    : isObject(val) ? astExprObject(val, opt)
     : error('Invalid input');
 }
 
-function astExprList(arr) {
-  return toArray(arr).map(astExpr).flat();
+function astExprList(arr, opt) {
+  return toArray(arr).map(val => astExpr(val, opt)).flat();
 }
 
-function astExprNumber(val) {
-  return isNumber(val) ? val : astExprObject(val);
+function astExprNumber(val, opt) {
+  return isNumber(val) ? val : astExprObject(val, opt);
 }
 
-function astJoinKeys(val) {
+function astJoinKeys(val, opt) {
   return isArray(val)
-    ? val.map(astExprList)
-    : astExprObject(val, { join: true });
+    ? val.map(subVal => astExprList(subVal, opt))
+    : astExprObject(val, { ...opt, join: true });
 }
 
-function astJoinValues(val) {
+function astJoinValues(val, opt) {
   return isArray(val)
     ? val.map((v, i) => i < 2
         ? astExprList(v)
-        : astExprObject(v, { join: true })
+        : astExprObject(v, { ...opt, join: true })
       )
-    : astExprObject(val, { join: true });
+    : astExprObject(val, { ...opt, join: true });
 }
 
 function astTableRef(value) {

--- a/src/query/to-ast.js
+++ b/src/query/to-ast.js
@@ -37,16 +37,16 @@ const Methods = {
   [SelectionList]: astSelectionList
 };
 
-export default function(value, type, propTypes) {
+export default function(value, type, propTypes, opt) {
   return type === TableRef ? astTableRef(value)
     : type === TableRefList ? value.map(astTableRef)
-    : ast(toObject(value), type, propTypes);
+    : ast(toObject(value), type, propTypes, opt);
 }
 
-function ast(value, type, propTypes) {
+function ast(value, type, propTypes, opt) {
   return type === Options
     ? (value ? astOptions(value, propTypes) : value)
-    : Methods[type](value);
+    : Methods[type](value, opt);
 }
 
 function astOptions(value, types = {}) {

--- a/src/query/verb.js
+++ b/src/query/verb.js
@@ -101,10 +101,10 @@ export class Verb {
    * to translate Arquero verbs to alternative data processing platforms.
    * @returns {object} A JSON-compatible abstract syntax tree object.
    */
-  toAST() {
+  toAST(opt) {
     const obj = { type: VerbType, verb: this.verb };
     this.schema.forEach(({ name, type, props }) => {
-      obj[name] = toAST(this[name], type, props);
+      obj[name] = toAST(this[name], type, props, opt);
     });
     return obj;
   }


### PR DESCRIPTION
As far as I can tell, the `Options` type is incapable of using params, so I've elected not to pass opt to astOptions (or astTableRef for that matter)

At the moment, getParams is exclusive - so you either get table.params, OR {...t1.params, t2.params} OR query.params. Merging a table or constituent tables' params with those embedded in a query makes sense, though it's uncertain which should have higher precedence.