### PR TITLE
Fix use of multiple rolling window frames in the same derive.

### DIFF
--- a/src/engine/window/window.js
+++ b/src/engine/window/window.js
@@ -5,7 +5,7 @@ import unroll from '../../util/unroll';
 import windowState from './window-state';
 
 const frameValue = op =>
-  (op.frame || [null, null]).map(v => Number.isFinite(v) ? v : null);
+  (op.frame || [null, null]).map(v => Number.isFinite(v) ? Math.abs(v) : null);
 
 const peersValue = op => !!op.peers;
 

--- a/src/expression/parse.js
+++ b/src/expression/parse.js
@@ -30,7 +30,7 @@ export default function(input, opt = {}) {
   // parser context
   const ctx = {
     op(op) {
-      const key = `${op.name}(${op.fields.concat(op.params).join(',')})`;
+      const key = opKey(op);
       return opcall[key] || (op.id = ++opId, opcall[key] = op);
     },
     field(node) {
@@ -93,6 +93,15 @@ export default function(input, opt = {}) {
   ops.forEach(op => op.fields = op.fields.map(id => f[id]));
 
   return { names, exprs, ops };
+}
+
+function opKey(op) {
+  let key = `${op.name}(${op.fields.concat(op.params).join(',')})`;
+  if (op.frame) {
+    const frame = op.frame.map(v => Number.isFinite(v) ? Math.abs(v) : -1);
+    key += `[${frame},${!!op.peers}]`;
+  }
+  return key;
 }
 
 function getParams(opt) {

--- a/test/verbs/derive-test.js
+++ b/test/verbs/derive-test.js
@@ -198,6 +198,27 @@ tape('derive supports parameters', t => {
   t.end();
 });
 
+tape('derive supports differing window frames', t => {
+  const dt = table({ x: [1, 2, 3, 4, 5, 6] })
+    .derive({
+      cs0: rolling(d => op.sum(d.x)),
+      cs4: rolling(d => op.sum(d.x), [-4, 0]),
+      cs2: rolling(d => op.sum(d.x), [-2, 0])
+    });
+
+  tableEqual(t, dt,
+    {
+      x:   [1, 2, 3,  4,  5,  6],
+      cs0: [1, 3, 6, 10, 15, 21],
+      cs4: [1, 3, 6, 10, 15, 20],
+      cs2: [1, 3, 6,  9, 12, 15]
+    },
+    'derive data'
+  );
+
+  t.end();
+});
+
 tape('derive supports streaming value windows', t => {
   const dt = table({ val: [1, 2, 3, 4, 5] })
     .orderby('val')


### PR DESCRIPTION
- Fix operator parsing lookup key to include rolling window frame information.

Close #232.