### PR TITLE
Make pivot count respect pivot keys.

### DIFF
--- a/src/engine/pivot.js
+++ b/src/engine/pivot.js
@@ -15,9 +15,14 @@ export default function(table, on, values, options = {}) {
   // use custom toString method for proper field resolution
   const results = keys.map(
     k => aggregate(table, values.ops.map(op => {
+      if (op.name === 'count') { // fix #273
+        const fn = r => k === keyColumn[r] ? 1 : NaN;
+        fn.toString = () => k + ':1';
+        return { ...op, name: 'sum', fields: [fn] };
+      }
       const fields = op.fields.map(f => {
         const fn = (r, d) => k === keyColumn[r] ? f(r, d) : NaN;
-        fn.toString = () => k + ':' + f + '';
+        fn.toString = () => k + ':' + f;
         return fn;
       });
       return { ...op, fields };

--- a/test/verbs/pivot-test.js
+++ b/test/verbs/pivot-test.js
@@ -128,3 +128,15 @@ tape('pivot handles filtered and ordered table', t => {
 
   t.end();
 });
+
+tape('pivot handles count aggregates', t => {
+  const data = {
+    k: ['a', 'b', 'b']
+  };
+
+  const ut = table(data).pivot('k', { count: op.count() });
+  tableEqual(t, ut, {
+    a: [ 1 ], b: [ 2 ]
+  }, 'pivot data');
+  t.end();
+});


### PR DESCRIPTION
Update pivot verb implementation to make count aggregates perform per-key counts, not global counts.

Fixes #273.