### PR TITLE
feat: add deno target to rollup build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-replace": "^4.0.0",
     "eslint": "^8.9.0",
     "esm": "^3.2.25",
     "rimraf": "^3.0.2",
@@ -55,6 +56,9 @@
   },
   "esm": {
     "force": true,
-    "mainFields": ["module", "main"]
+    "mainFields": [
+      "module",
+      "main"
+    ]
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,56 +2,73 @@ import json from '@rollup/plugin-json';
 import bundleSize from 'rollup-plugin-bundle-size';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
+import replace from '@rollup/plugin-replace';
 
 function onwarn(warning, defaultHandler) {
-  if (warning.code !== 'CIRCULAR_DEPENDENCY') {
-    defaultHandler(warning);
-  }
+    if (warning.code !== 'CIRCULAR_DEPENDENCY') {
+        defaultHandler(warning);
+    }
 }
 
 const name = 'aq';
-const external = [ 'apache-arrow', 'node-fetch' ];
+const external = ['apache-arrow', 'node-fetch'];
 const globals = { 'apache-arrow': 'Arrow' };
 const plugins = [
-  json(),
-  bundleSize(),
-  nodeResolve({ modulesOnly: true })
+    json(),
+    bundleSize(),
+    nodeResolve({ modulesOnly: true })
 ];
 
 export default [
-  {
-    input: 'src/index-node.js',
-    external: ['acorn'].concat(external),
-    plugins,
-    onwarn,
-    output: [
-      {
-        file: 'dist/arquero.node.js',
-        format: 'cjs',
-        name
-      }
-    ]
-  },
-  {
-    input: 'src/index.js',
-    external,
-    plugins,
-    onwarn,
-    output: [
-      {
-        file: 'dist/arquero.js',
-        format: 'umd',
-        globals,
-        name
-      },
-      {
-        file: 'dist/arquero.min.js',
-        format: 'umd',
-        sourcemap: true,
-        plugins: [ terser({ ecma: 2018 }) ],
-        globals,
-        name
-      }
-    ]
-  }
+    {
+        input: 'src/index-node.js',
+        external: ['acorn'].concat(external),
+        plugins,
+        onwarn,
+        output: [
+            {
+                file: 'dist/arquero.node.js',
+                format: 'cjs',
+                name
+            }
+        ]
+    },
+    {
+        input: 'src/index.js',
+        plugins: [
+            replace({
+                values: { 'apache-arrow': 'https://cdn.skypack.dev/apache-arrow@8.0.0' },
+                preventAssignment: true,
+                delimiters: ['\\b', '\\b(?!@)']
+            }),
+            ...plugins
+        ],
+        output: [{
+            file: 'dist/arquero.deno.js',
+            format: 'es',
+            name
+        }]
+    },
+    {
+        input: 'src/index.js',
+        external,
+        plugins,
+        onwarn,
+        output: [
+            {
+                file: 'dist/arquero.js',
+                format: 'umd',
+                globals,
+                name
+            },
+            {
+                file: 'dist/arquero.min.js',
+                format: 'umd',
+                sourcemap: true,
+                plugins: [terser({ ecma: 2018 })],
+                globals,
+                name
+            }
+        ]
+    }
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,14 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
+"@rollup/plugin-replace@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz#e34c457d6a285f0213359740b43f39d969b38a67"
+  integrity sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
 "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -1074,6 +1082,13 @@ lodash.padend@^4.6.1:
   resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
   integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
 
+magic-string@^0.25.7:
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
+  dependencies:
+    sourcemap-codec "^1.4.8"
+
 maxmin@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/maxmin/-/maxmin-2.1.0.tgz#4d3b220903d95eee7eb7ac7fa864e72dc09a3166"
@@ -1371,6 +1386,11 @@ source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 string.prototype.trim@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
This is a proof of concept to display a working build for #280.

Currently the Arquero distribution on Skypack does not work with Deno. This PR allows a cursory look into adding Deno as a distribution target. To see it in use, build Arquero normally (`yarn build`), then in a Deno REPL (assuming the current working directory is Arquero's root):
```js
const aq = await import('./dists/arquero.deno.js');
```