### PR TITLE
v5.0.0

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -102,7 +102,6 @@ This method performs parsing only. To both load and parse an Arrow file, use [lo
 * *arrowTable*: An [Apache Arrow](https://arrow.apache.org/docs/js/) data table or a byte array (e.g., [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)) in the Arrow IPC format.
 * *options*: An Arrow import options object:
   * *columns*: An ordered set of columns to import. The input may consist of: column name strings, column integer indices, objects with current column names as keys and new column names as values (for renaming), or a selection helper function such as [all](#all), [not](#not), or [range](#range)).
-  * *unpack*: _As of v2.3.0, this option is deprecated and ignored if specified. Instead, Arquero now efficiently handles Arrow columns internally._ A boolean flag (default `false`) to unpack binary-encoded Arrow data to standard JavaScript values. Unpacking can incur an upfront time and memory cost to extract data to new arrays, but can speed up later query processing by enabling faster data access.
 
 *Examples*
 
@@ -418,9 +417,9 @@ Create an [Apache Arrow](https://arrow.apache.org/docs/js/) table for the input 
   * *columns*: Ordered list of column names to include. If function-valued, the function should accept the input *data* as a single argument and return an array of column name strings.
   * *limit*: The maximum number of rows to include (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
-  * *types*: An optional object indicating the [Arrow data type](https://arrow.apache.org/docs/js/enums/type.html) to use for named columns. If specified, the input should be an object with column names for keys and Arrow data types for values. If a column's data type is not explicitly provided, type inference will be performed.
+  * *types*: An optional object indicating the [Arrow data type](https://arrow.apache.org/docs/js/enums/Arrow_dom.Type.html) to use for named columns. If specified, the input should be an object with column names for keys and Arrow data types for values. If a column's data type is not explicitly provided, type inference will be performed.
 
-    Type values can either be instantiated Arrow [DataType](https://arrow.apache.org/docs/js/classes/datatype.html) instances (for example, `new Float64()`,`new DateMilliseconds()`, *etc.*) or type enum codes (`Type.Float64`, `Type.Date`, `Type.Dictionary`). For convenience, arquero re-exports the apache-arrow `Type` enum object (see examples below). High-level types map to specific data type instances as follows:
+    Type values can either be instantiated Arrow [DataType](https://arrow.apache.org/docs/js/classes/Arrow_dom.DataType.html) instances (for example, `new Float64()`,`new DateMilliseconds()`, *etc.*) or type enum codes (`Type.Float64`, `Type.Date`, `Type.Dictionary`). High-level types map to specific data type instances as follows:
 
     * `Type.Date` → `new DateMilliseconds()`
     * `Type.Dictionary` → `new Dictionary(new Utf8(), new Int32())`
@@ -436,7 +435,8 @@ Create an [Apache Arrow](https://arrow.apache.org/docs/js/) table for the input 
 Encode Arrow data from an input Arquero table:
 
 ```js
-const { table, toArrow, Type } = require('arquero');
+import { table, toArrow } from 'arquero';
+import { Type } from 'apache-arrow';
 
 // create Arquero table
 const dt = table({
@@ -465,7 +465,7 @@ const bytes = at1.serialize();
 Encode Arrow data from an input object array:
 
 ```js
-const { toArrow } = require('arquero-arrow');
+import { toArrow } from 'arquero';
 
 // encode object array as an Arrow table (infer data types)
 const at = toArrow([

--- a/docs/api/table.md
+++ b/docs/api/table.md
@@ -589,9 +589,9 @@ Format this table as an [Apache Arrow](https://arrow.apache.org/docs/js/) table 
   * *columns*: Ordered list of column names to include. If function-valued, the function should accept this table as a single argument and return an array of column name strings.
   * *limit*: The maximum number of rows to include (default `Infinity`).
   * *offset*: The row offset indicating how many initial rows to skip (default `0`).
-  * *types*: An optional object indicating the [Arrow data type](https://arrow.apache.org/docs/js/enums/type.html) to use for named columns. If specified, the input should be an object with column names for keys and Arrow data types for values. If a column's data type is not explicitly provided, type inference will be performed.
+  * *types*: An optional object indicating the [Arrow data type](https://arrow.apache.org/docs/js/enums/Arrow_dom.Type.html) to use for named columns. If specified, the input should be an object with column names for keys and Arrow data types for values. If a column's data type is not explicitly provided, type inference will be performed.
 
-    Type values can either be instantiated Arrow [DataType](https://arrow.apache.org/docs/js/classes/datatype.html) instances (for example, `new Float64()`,`new DateMilliseconds()`, *etc.*) or type enum codes (`Type.Float64`, `Type.Date`, `Type.Dictionary`). For convenience, arquero re-exports the apache-arrow `Type` enum object (see examples below). High-level types map to specific data type instances as follows:
+    Type values can either be instantiated Arrow [DataType](https://arrow.apache.org/docs/js/classes/Arrow_dom.DataType.html) instances (for example, `new Float64()`,`new DateMilliseconds()`, *etc.*) or type enum codes (`Type.Float64`, `Type.Date`, `Type.Dictionary`). High-level types map to specific data type instances as follows:
 
     * `Type.Date` → `new DateMilliseconds()`
     * `Type.Dictionary` → `new Dictionary(new Utf8(), new Int32())`
@@ -607,7 +607,8 @@ Format this table as an [Apache Arrow](https://arrow.apache.org/docs/js/) table 
 Encode Arrow data from an input Arquero table:
 
 ```js
-const { table, Type } = require('arquero');
+import { table } from 'arquero';
+import { Type } from 'apache-arrow';
 
 // create Arquero table
 const dt = table({
@@ -642,7 +643,7 @@ This method will throw an error if type inference fails or if the generated colu
 Encode Arrow data from an input Arquero table:
 
 ```js
-const { table } = require('arquero');
+import { table } from 'arquero';
 
 const dt = table({
   x: [1, 2, 3, 4, 5],


### PR DESCRIPTION
Changes from [v4.8.8](https://github.com/uwdata/arquero/releases/tag/v4.8.8):

- *Breaking.* Update to Apache Arrow v8.0, remove export of arrow `Type` enum. To specify types using integer type ids, use the Apache Arrow `Type` export directly. Arrow v8.0 has a significant number of API changes that affect calls to Arrow tables produced by Arquero. For example, `arrowTable.getColumn()` no longer exists, use `arrowTable.getChild()` instead.
- Fix pivot count aggregation to respect pivot keys. (#273)
- Update dependencies.