### PR TITLE
Adds the option for toArrowIPC to write to stream or file formats

### DIFF
--- a/src/format/to-arrow.js
+++ b/src/format/to-arrow.js
@@ -3,6 +3,11 @@ import { tableToIPC } from 'apache-arrow';
 
 export default toArrow;
 
-export function toArrowIPC(table, options) {
-  return tableToIPC(toArrow(table, options));
+export function toArrowIPC(table, options = {}) {
+  const { format: format, ...toArrowOptions } = options;
+  const outputFormat = format ? format : 'stream';
+  if (!['stream', 'file'].includes(outputFormat)) {
+    throw Error('Unrecognised output format');
+  }
+  return tableToIPC(toArrow(table, toArrowOptions), format);
 }

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -300,7 +300,8 @@ export default class ColumnTable extends Table {
 
   /**
    * Format this table as binary data in the Apache Arrow IPC format.
-   * @param {ArrowFormatOptions} [options] The formatting options.
+   * @param {ArrowFormatOptions} [options] The formatting options. Set {format: 'stream'} 
+   *        or {format:"file"} for specific IPC format
    * @return {Uint8Array} A new Uint8Array of Arrow-encoded binary data.
    */
   toArrowBuffer(options) {

--- a/test/format/to-arrow-test.js
+++ b/test/format/to-arrow-test.js
@@ -233,3 +233,71 @@ tape('toArrow respects limit and types option', t => {
 
   t.end();
 });
+
+tape('toArrowBuffer generates the correct output for file option', (t) => {
+  const dt = table({
+    w: ['a', 'b', 'a'],
+    x: [1, 2, 3],
+    y: [1.6181, 2.7182, 3.1415],
+    z: [true, true, false]
+  });
+
+  const buffer = dt.toArrowBuffer({ format: 'file' });
+
+  t.deepEqual(
+    buffer.slice(0, 8),
+    new Uint8Array([65, 82, 82, 79, 87, 49, 0, 0])
+  );
+  t.end();
+});
+
+tape('toArrowBuffer generates the correct output for stream option', (t) => {
+  const dt = table({
+    w: ['a', 'b', 'a'],
+    x: [1, 2, 3],
+    y: [1.6181, 2.7182, 3.1415],
+    z: [true, true, false]
+  });
+
+  const buffer = dt.toArrowBuffer({ format: 'stream' });
+
+  t.deepEqual(
+    buffer.slice(0, 8),
+    new Uint8Array([255, 255, 255, 255, 72, 1, 0, 0])
+  );
+  t.end();
+});
+
+tape('toArrowBuffer defaults to using stream option', (t) => {
+  const dt = table({
+    w: ['a', 'b', 'a'],
+    x: [1, 2, 3],
+    y: [1.6181, 2.7182, 3.1415],
+    z: [true, true, false]
+  });
+
+  const buffer = dt.toArrowBuffer();
+
+  t.deepEqual(
+    buffer.slice(0, 8),
+    new Uint8Array([255, 255, 255, 255, 72, 1, 0, 0])
+  );
+  t.end();
+});
+
+tape(
+  'toArrowBuffer throws an error if the format is not stream or file',
+  (t) => {
+    t.throws(() => {
+      const dt = table({
+        w: ['a', 'b', 'a'],
+        x: [1, 2, 3],
+        y: [1.6181, 2.7182, 3.1415],
+        z: [true, true, false]
+      });
+
+      dt.toArrowBuffer({ format: 'nonsense' });
+    }, 'Unrecognised output format');
+    t.end();
+  }
+);


### PR DESCRIPTION
When serializing to IPC format using 

```javascript
table.toArrowBuffer()
``` 

There is no way to specify if the serialization should be in IPC "stream" or "file" format.

The call to tableToIPC here:

https://github.com/uwdata/arquero/blob/074e1efdb6b8df2ca125db0c36020a8feb1d2d66/src/format/to-arrow.js#L6-L8

does not allow any passing of the second option defined in apache-arrow 

https://github.com/apache/arrow/blob/5611f2bd0d6136b005d137a84b50709fc5c813bb/js/src/ipc/serialization.ts#L61-L65


This PR adds a {format} option to the options parameter of toArrowBuffer to allow specification of the IPC format