### PR TITLE
iso-date-string: add check for invalid dates

### DIFF
--- a/src/util/is-iso-date-string.js
+++ b/src/util/is-iso-date-string.js
@@ -1,5 +1,5 @@
 const iso_re = /^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/;
 
 export default function(value) {
-  return value.match(iso_re);
+  return value.match(iso_re) && !isNaN(Date.parse(value));
 }

--- a/test/format/from-csv-test.js
+++ b/test/format/from-csv-test.js
@@ -43,6 +43,7 @@ tape('fromCSV infers types', t => {
     new Date(2000, 0, 1).toISOString(),
     new Date(1979, 3, 14, 3, 45).toISOString()
   ], v => v instanceof Date);
+  check('date-like strings', ['2022-23', '2023-24'], v => typeof v === 'string');
   t.end();
 });
 

--- a/test/format/from-json-test.js
+++ b/test/format/from-json-test.js
@@ -132,14 +132,14 @@ tape('fromJSON parses JSON text with parse option as data only', t => {
 
 tape('fromJSON parses ISO date strings', t => {
   const values = [
-    0, '', '2.1', '2000',
+    0, '', '2.1', '2000', '2022-2023',
     new Date(Date.UTC(2000, 0, 1)),
     new Date(Date.UTC(2000, 0, 1)),
     new Date(2021, 0, 6, 12),
     new Date(2021, 0, 6, 4)
   ];
   const str = [
-    0, '', '2.1', '2000',
+    0, '', '2.1', '2000', '2022-2023',
     '2000-01',
     '2000-01-01',
     '2021-01-06T12:00:00.000',


### PR DESCRIPTION
This commit adds a check and tests for invalid dates which still might pass a regex test. I found this is common with government datasets which include years in the format: "2017-18". Technically it still passes the YYYY-MM check, but should not be treated as a date.

```js
const t = aq.fromCSV("year\n2019-20\n2021-22")
t.get('year', 0) // Invalid Date
```