### PR TITLE
Fixed errors in type documentation

### DIFF
--- a/src/op/window-functions.js
+++ b/src/op/window-functions.js
@@ -10,10 +10,25 @@ import NULL from '../util/null';
  */
 
 /**
+ * A storage object for the state of the window.
+ * @typedef {import('../engine/window/window-state').default} WindowState
+ */
+
+/**
  * Retrieve an output value from a window operator.
  * @callback WindowValue
  * @param {WindowState} state The window state object.
  * @return {*} The output value.
+ */
+
+/**
+ * Initialize an aggregate operator.
+ * @typedef {import('./aggregate-functions').AggregateInit} AggregateInit
+ */
+
+/**
+ * Retrive an output value from an aggregate operator.
+ * @typedef {import('./aggregate-functions').AggregateValue} AggregateValue
  */
 
 /**
@@ -28,6 +43,11 @@ import NULL from '../util/null';
  * @callback WindowCreate
  * @param {...any} params The aggregate operator parameters.
  * @return {WindowOperator} The instantiated window operator.
+ */
+
+/**
+ * Create a new aggregate operator instance.
+ * @typedef {import('./aggregate-functions').AggregateCreate} AggregateCreate
  */
 
 /**

--- a/src/query/query.js
+++ b/src/query/query.js
@@ -146,6 +146,11 @@ export default class Query extends Transformable {
 }
 
 /**
+ * Abstract class representing a data table.
+ * @typedef {import('../table/table').default} Table
+ */
+
+/**
  * Serialized object representation of a query.
  * @typedef {object} QueryObject
  * @property {object[]} verbs An array of verb definitions.

--- a/src/query/verb.js
+++ b/src/query/verb.js
@@ -241,3 +241,8 @@ export const Verbs = {
                 { name: 'tables', type: TableRefList }
               ])
 };
+
+/**
+ * Abstract class representing a data table.
+ * @typedef {import('../table/table').default} Table
+ */

--- a/src/table/column-table.js
+++ b/src/table/column-table.js
@@ -79,7 +79,7 @@ export default class ColumnTable extends Table {
    * based on the values of the optional configuration argument. If a
    * setting is not specified, it is inherited from the current table.
    * @param {CreateOptions} [options] Creation options for the new table.
-   * @return {ColumnTable} A newly created table.
+   * @return {this} A newly created table.
    */
   create({ data, names, filter, groups, order }) {
     const f = filter !== undefined ? filter : this.mask();
@@ -146,9 +146,9 @@ export default class ColumnTable extends Table {
    * Get an array of values contained in a column. The resulting array
    * respects any table filter or orderby criteria.
    * @param {string} name The column name.
-   * @param {ArrayConstructor|import('./table').TypedArrayConstructor} [constructor=Array]
+   * @param {ArrayConstructor|TypedArrayConstructor} [constructor=Array]
    *  The array constructor for instantiating the output array.
-   * @return {import('./table').DataValue[]|import('./table).TypedArray} The array of column values.
+   * @return {DataValue[]|TypedArray} The array of column values.
    */
   array(name, constructor = Array) {
     const column = this.column(name);
@@ -162,7 +162,7 @@ export default class ColumnTable extends Table {
    * Get the value for the given column and row.
    * @param {string} name The column name.
    * @param {number} [row=0] The row index, defaults to zero if not specified.
-   * @return {import('./table').DataValue} The table value at (column, row).
+   * @return {DataValue} The table value at (column, row).
    */
   get(name, row = 0) {
     const column = this.column(name);
@@ -176,7 +176,7 @@ export default class ColumnTable extends Table {
    * function takes a row index as its single argument and returns the
    * corresponding column value.
    * @param {string} name The column name.
-   * @return {import('./table').ColumnGetter} The column getter function.
+   * @return {ColumnGetter} The column getter function.
    */
   getter(name) {
     const column = this.column(name);
@@ -240,7 +240,7 @@ export default class ColumnTable extends Table {
    * Instead, the backing data itself is filtered and ordered as needed.
    * @param {number[]} [indices] Ordered row indices to materialize.
    *  If unspecified, all rows passing the table filter are used.
-   * @return {ColumnTable} A reified table.
+   * @return {this} A reified table.
    */
   reify(indices) {
     const nrows = indices ? indices.length : this.numRows();
@@ -364,6 +364,36 @@ function objectBuilder(table) {
 
   return b;
 }
+
+/**
+ * Options for derived table creation.
+ * @typedef {import('./table').CreateOptions} CreateOptions
+ */
+
+/**
+ * A typed array constructor.
+ * @typedef {import('./table').TypedArrayConstructor} TypedArrayConstructor
+ */
+
+/**
+ * A typed array instance.
+ * @typedef {import('./table').TypedArray} TypedArray
+ */
+
+/**
+ * Table value.
+ * @typedef {import('./table').DataValue} DataValue
+ */
+
+/**
+ * Column value accessor.
+ * @typedef {import('./table').ColumnGetter} ColumnGetter
+ */
+
+/**
+ * Options for generating row objects.
+ * @typedef {import('./table').ObjectsOptions} ObjectsOptions
+ */
 
 /**
  * A table transformation.

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -525,6 +525,11 @@ export default class Table extends Transformable {
  */
 
 /**
+ * Abstract class for custom aggregation operations.
+ * @typedef {import('../engine/reduce/reducer').default} Reducer
+ */
+
+/**
  * A table groupby specification.
  * @typedef {object} GroupBySpec
  * @property {number} size The number of groups.

--- a/src/table/transformable.js
+++ b/src/table/transformable.js
@@ -756,7 +756,7 @@ export default class Transformable {
 
 /**
  * A function defined over rows from two tables.
- * @typedef {(a?: Struct, b?: Struct, $?: Params) => any} TableFunc2
+ * @typedef {(a?: Struct, b?: Struct, $?: Params) => any} TableExprFunc2
  */
 
 /**


### PR DESCRIPTION
Building with `npm run build` resulted in broken Typescript types in several files.
This PR fixes the JSDoc used in `src/` so that the built module has no Typescript errors.
Fixes #332 