### PR TITLE
Fix wrong ToC link in verbs.md

### DIFF
--- a/docs/api/verbs.md
+++ b/docs/api/verbs.md
@@ -5,7 +5,7 @@ title: Verbs \| Arquero API Reference
 
 [Top-Level](/arquero/api) | [Table](table) | [**Verbs**](verbs) | [Op Functions](op) | [Expressions](expressions) | [Extensibility](extensibility)
 
-* [Core Verbs](#verbs)
+* [Core Verbs](#core-verbs)
   * [derive](#derive)
   * [filter](#filter), [slice](#slice)
   * [groupby](#groupby), [ungroup](#ungroup)


### PR DESCRIPTION
Tiny fix - link to section in table of contents of Verbs page was wrong